### PR TITLE
Fix province filter and vendor dropdown

### DIFF
--- a/app/graphql/crud/provinces.py
+++ b/app/graphql/crud/provinces.py
@@ -8,6 +8,11 @@ def get_provinces(db: Session):
     return db.query(Provinces).all()
 
 
+def get_provinces_by_country(db: Session, country_id: int):
+    """Obtener provincias filtradas por CountryID"""
+    return db.query(Provinces).filter(Provinces.CountryID == country_id).all()
+
+
 def get_provinces_by_id(db: Session, provinceid: int):
     return db.query(Provinces).filter(Provinces.ProvinceID == provinceid).first()
 

--- a/app/graphql/resolvers/provinces.py
+++ b/app/graphql/resolvers/provinces.py
@@ -2,7 +2,11 @@
 import strawberry
 from typing import List, Optional
 from app.graphql.schemas.provinces import ProvincesInDB
-from app.graphql.crud.provinces import get_provinces, get_provinces_by_id
+from app.graphql.crud.provinces import (
+    get_provinces,
+    get_provinces_by_id,
+    get_provinces_by_country,
+)
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
 from strawberry.types import Info
@@ -44,6 +48,24 @@ class ProvincesQuery:
                 }
                 return ProvincesInDB(**filtered)
             return None
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def provinces_by_country(self, info: Info, countryID: int) -> List[ProvincesInDB]:
+        """Obtener provincias filtradas por país"""
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            provinces = get_provinces_by_country(db, countryID)
+            return [
+                ProvincesInDB(
+                    ProvinceID=int(p.ProvinceID),
+                    CountryID=int(p.CountryID),
+                    Name=str(p.Name)
+                )
+                for p in provinces
+            ]
         finally:
             db_gen.close()
 

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -48,6 +48,7 @@ from app.graphql.resolvers.useractions import UseractionsQuery
 from app.graphql.resolvers.users import UsersQuery
 from app.graphql.resolvers.warehouses import WarehousesQuery
 from app.graphql.resolvers.vendors import VendorsQuery
+from app.graphql.mutations.clients import ClientsMutations
 
 # IMPORTANTE: Importar las clases de autenticación correctamente
 from app.graphql.resolvers.auth import AuthQuery
@@ -312,8 +313,8 @@ class Query(
         )
 
 # MUTATION PRINCIPAL - COMPLETAMENTE CORREGIDO
-@strawberry.type  
-class Mutation:
+@strawberry.type
+class Mutation(ClientsMutations):
     """Mutaciones principales"""
     
     # ========== MUTACIONES DE AUTENTICACIÓN ==========

--- a/frontend/src/components/TableFilters.jsx
+++ b/frontend/src/components/TableFilters.jsx
@@ -18,6 +18,12 @@ const pluralMap = {
     Brand: "Brands",
 };
 
+const nameFieldMap = {
+    Vendor: "VendorName",
+};
+
+const getNameField = (model) => nameFieldMap[model] || "Name";
+
 const getQueryName = (model) => {
     const plural = pluralMap[model] || `${model}s`;
     return `all${plural}`;
@@ -67,11 +73,12 @@ export default function TableFilters({ modelName, data, onFilterChange }) {
                 if (field.type === "select" && !field.dependsOn) {
                     // Cargar opciones de select simples
                     const queryName = getQueryName(field.relationModel);
+                    const nameField = getNameField(field.relationModel);
                     const QUERY = `
             query {
               ${queryName} {
                 ${field.relationModel}ID
-                Name
+                ${nameField}
               }
             }
           `;
@@ -112,11 +119,12 @@ export default function TableFilters({ modelName, data, onFilterChange }) {
             `;
                         variables = { countryID: parseInt(parentValue) };
                     } else {
+                        const nameField = getNameField(field.relationModel);
                         QUERY = `
               query {
                 ${queryName} {
                   ${field.relationModel}ID
-                  Name
+                  ${nameField}
                 }
               }
             `;
@@ -239,7 +247,7 @@ export default function TableFilters({ modelName, data, onFilterChange }) {
                     <option value="">Todos</option>
                     {(options[field.field] || []).map(opt => (
                         <option key={opt[`${field.relationModel}ID`]} value={opt[`${field.relationModel}ID`]}>
-                            {opt.Name}
+                            {opt[getNameField(field.relationModel)]}
                         </option>
                     ))}
                 </select>

--- a/frontend/src/utils/graphqlClient.js
+++ b/frontend/src/utils/graphqlClient.js
@@ -429,31 +429,31 @@ export const clientHelpers = {
     validateClientData(clientData) {
         const errors = [];
 
-        if (!clientData.FirstName?.trim()) {
+        if (!clientData.firstName?.trim()) {
             errors.push("El nombre es obligatorio");
         }
 
-        if (!clientData.DocTypeID) {
+        if (!clientData.docTypeID) {
             errors.push("El tipo de documento es obligatorio");
         }
 
-        if (!clientData.CountryID) {
+        if (!clientData.countryID) {
             errors.push("El país es obligatorio");
         }
 
-        if (!clientData.ProvinceID) {
+        if (!clientData.provinceID) {
             errors.push("La provincia es obligatoria");
         }
 
-        if (!clientData.PriceListID) {
+        if (!clientData.priceListID) {
             errors.push("La lista de precios es obligatoria");
         }
 
-        if (!clientData.VendorID) {
+        if (!clientData.vendorID) {
             errors.push("El vendedor es obligatorio");
         }
 
-        if (clientData.Email && !this.isValidEmail(clientData.Email)) {
+        if (clientData.email && !this.isValidEmail(clientData.email)) {
             errors.push("El formato del email no es válido");
         }
 
@@ -469,8 +469,8 @@ export const clientHelpers = {
     // Preparar datos para crear cliente
     prepareClientData(formData) {
         return {
-            DocTypeID: parseInt(formData.DocTypeID) || 1,
-            DocNumber: formData.DocNumber?.trim() || null,
+            DocTypeID: parseInt(formData.docTypeID) || 1,
+            DocNumber: formData.docNumber?.trim() || null,
             FirstName: formData.firstName?.trim() || "",
             LastName: formData.lastName?.trim() || null,
             Phone: formData.phone?.trim() || null,


### PR DESCRIPTION
## Summary
- add `get_provinces_by_country` CRUD helper and resolver
- expose client mutations via main schema
- fix vendor select name field in filters
- adjust filter queries to use new helper

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm test` *(fails: Missing script "test")*
- `python -m py_compile app/graphql/crud/provinces.py app/graphql/resolvers/provinces.py app/graphql/schema.py`

------
https://chatgpt.com/codex/tasks/task_e_6865e3b0632083238a719e2a7bf39c48