### PR TITLE
Fix GraphQL client mutations

### DIFF
--- a/app/graphql/mutations/clients.py
+++ b/app/graphql/mutations/clients.py
@@ -3,10 +3,11 @@ import strawberry
 from typing import Optional
 from app.graphql.schemas.clients import ClientsCreate, ClientsUpdate, ClientsInDB
 from app.graphql.crud.clients import (
-    create_clients, 
-    update_clients, 
+    create_clients,
+    update_clients,
     delete_clients,
 )
+from app.utils import obj_to_schema
 from app.db import get_db
 from strawberry.types import Info
 
@@ -18,7 +19,7 @@ class ClientsMutations:
         db = next(db_gen)
         try:
             new_client = create_clients(db, data)
-            return ClientsInDB(**new_client.__dict__)
+            return obj_to_schema(ClientsInDB, new_client)
         finally:
             db_gen.close()
 
@@ -30,7 +31,7 @@ class ClientsMutations:
             updated_client = update_clients(db, clientID, data)
             if not updated_client:
                 return None
-            return ClientsInDB(**updated_client.__dict__)
+            return obj_to_schema(ClientsInDB, updated_client)
         finally:
             db_gen.close()
 
@@ -53,6 +54,6 @@ class ClientsMutations:
             updated_client = update_clients(db, clientID, update_data)
             if not updated_client:
                 return None
-            return ClientsInDB(**updated_client.__dict__)
+            return obj_to_schema(ClientsInDB, updated_client)
         finally:
             db_gen.close()

--- a/app/graphql/mutations/useraccess.py
+++ b/app/graphql/mutations/useraccess.py
@@ -7,6 +7,7 @@ from app.graphql.crud.useraccess import (
     create_useraccess,
     delete_useraccess,
 )
+from app.utils import obj_to_schema
 from app.db import get_db
 from strawberry.types import Info
 
@@ -17,7 +18,7 @@ class UserAccessMutation:
     def create_useraccess(self, info: Info, data: UserAccessCreate) -> UserAccessInDB:
         db = next(get_db())
         obj = create_useraccess(db, data)
-        return UserAccessInDB(**obj.__dict__)
+        return obj_to_schema(UserAccessInDB, obj)
 
     @strawberry.mutation
     def delete_useraccess(
@@ -53,4 +54,4 @@ class UserAccessMutation:
 
         # Crear nuevo acceso con los nuevos datos
         obj = create_useraccess(db, newData)
-        return UserAccessInDB(**obj.__dict__)
+        return obj_to_schema(UserAccessInDB, obj)

--- a/frontend/src/utils/graphqlClient.js
+++ b/frontend/src/utils/graphqlClient.js
@@ -362,7 +362,7 @@ export const MUTATIONS = {
     // CREAR CLIENTE
     CREATE_CLIENT: `
         mutation CreateClient($input: ClientsCreate!) {
-            createClient(input: $input) {
+            createClient(data: $input) {
                 ClientID
                 DocTypeID
                 DocNumber
@@ -385,7 +385,7 @@ export const MUTATIONS = {
     // ACTUALIZAR CLIENTE
     UPDATE_CLIENT: `
         mutation UpdateClient($clientID: Int!, $input: ClientsUpdate!) {
-            updateClient(clientID: $clientID, input: $input) {
+            updateClient(clientID: $clientID, data: $input) {
                 ClientID
                 DocTypeID
                 DocNumber


### PR DESCRIPTION
## Summary
- sanitize client and user access mutations with `obj_to_schema`
- GraphQL mutations use `data:` parameter so we don't include `_sa_instance_state`

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686601b9726c8323854e42aa77104bf4