### PR TITLE
Add supplier GraphQL CRUD and frontend integration

### DIFF
--- a/app/graphql/mutations/suppliers.py
+++ b/app/graphql/mutations/suppliers.py
@@ -1,0 +1,59 @@
+# app/graphql/mutations/suppliers.py
+import strawberry
+from typing import Optional
+from app.graphql.schemas.suppliers import SuppliersCreate, SuppliersUpdate, SuppliersInDB
+from app.graphql.crud.suppliers import (
+    create_suppliers,
+    update_suppliers,
+    delete_suppliers,
+)
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+@strawberry.type
+class SuppliersMutations:
+    @strawberry.mutation
+    def create_supplier(self, info: Info, data: SuppliersCreate) -> SuppliersInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            new_supplier = create_suppliers(db, data)
+            return obj_to_schema(SuppliersInDB, new_supplier)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_supplier(self, info: Info, supplierID: int, data: SuppliersUpdate) -> Optional[SuppliersInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated_supplier = update_suppliers(db, supplierID, data)
+            if not updated_supplier:
+                return None
+            return obj_to_schema(SuppliersInDB, updated_supplier)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_supplier(self, info: Info, supplierID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted_supplier = delete_suppliers(db, supplierID)
+            return deleted_supplier is not None
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def toggle_supplier_status(self, info: Info, supplierID: int, isActive: bool) -> Optional[SuppliersInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            update_data = SuppliersUpdate(IsActive=isActive)
+            updated_supplier = update_suppliers(db, supplierID, update_data)
+            if not updated_supplier:
+                return None
+            return obj_to_schema(SuppliersInDB, updated_supplier)
+        finally:
+            db_gen.close()

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -49,6 +49,7 @@ from app.graphql.resolvers.users import UsersQuery
 from app.graphql.resolvers.warehouses import WarehousesQuery
 from app.graphql.resolvers.vendors import VendorsQuery
 from app.graphql.mutations.clients import ClientsMutations
+from app.graphql.mutations.suppliers import SuppliersMutations
 
 # IMPORTANTE: Importar las clases de autenticación correctamente
 from app.graphql.resolvers.auth import AuthQuery
@@ -314,7 +315,7 @@ class Query(
 
 # MUTATION PRINCIPAL - COMPLETAMENTE CORREGIDO
 @strawberry.type
-class Mutation(ClientsMutations):
+class Mutation(ClientsMutations, SuppliersMutations):
     """Mutaciones principales"""
     
     # ========== MUTACIONES DE AUTENTICACIÓN ==========

--- a/frontend/src/pages/SupplierCreate.jsx
+++ b/frontend/src/pages/SupplierCreate.jsx
@@ -1,89 +1,136 @@
 import { useState } from "react";
-import apiFetch from "../utils/apiFetch";
+import { supplierOperations } from "../utils/graphqlClient";
 
-export default function SupplierCreate() {
-  const [supplier, setSupplier] = useState({
-    name: "",
-    address: "",
-    phone: "",
-    email: "",
-    Contact: "",
-    CUIT: "",
-    isActive: true,
-  });
+export default function SupplierCreate({ onClose, onSave, supplier: initialSupplier = null }) {
+    const [supplier, setSupplier] = useState({
+        docTypeID: null,
+        docNumber: "",
+        firstName: "",
+        lastName: "",
+        phone: "",
+        email: "",
+        address: "",
+        city: "",
+        postalCode: "",
+        countryID: null,
+        provinceID: null,
+        isActive: true,
+    });
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
 
-  const [error, setError] = useState(null);
+    useState(() => {
+        if (initialSupplier) {
+            setSupplier({
+                docTypeID: initialSupplier.DocTypeID,
+                docNumber: initialSupplier.DocNumber || "",
+                firstName: initialSupplier.FirstName || "",
+                lastName: initialSupplier.LastName || "",
+                phone: initialSupplier.Phone || "",
+                email: initialSupplier.Email || "",
+                address: initialSupplier.Address || "",
+                city: initialSupplier.City || "",
+                postalCode: initialSupplier.PostalCode || "",
+                countryID: initialSupplier.CountryID,
+                provinceID: initialSupplier.ProvinceID,
+                isActive: initialSupplier.IsActive !== false,
+            });
+        }
+    }, []);
 
-  const handleChange = (e) => {
-    const { name, value, type, checked } = e.target;
-    setSupplier((prev) => ({
-      ...prev,
-      [name]: type === "checkbox" ? checked : value,
-    }));
-  };
+    const handleChange = (e) => {
+        const { name, value, type, checked } = e.target;
+        setSupplier(prev => ({
+            ...prev,
+            [name]: type === "checkbox" ? checked : value,
+        }));
+    };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    try {
-      await apiFetch("/suppliers/", {
-        method: "POST",
-        body: supplier,
-      });
-      window.close(); // ✅ Cierra la ventana popup
-    } catch (e) {
-      console.error(e);
-      setError("Error al guardar el proveedor");
-    }
-  };
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            let result;
+            if (initialSupplier) {
+                result = await supplierOperations.updateSupplier(initialSupplier.SupplierID, supplier);
+            } else {
+                result = await supplierOperations.createSupplier(supplier);
+            }
+            if (onSave) onSave(result);
+            if (onClose) onClose();
+        } catch (err) {
+            console.error("Error guardando proveedor:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
 
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4 p-6 max-w-xl mx-auto">
-      <h2 className="text-xl font-bold">Nuevo Proveedor</h2>
-      {error && <p className="text-red-600">{error}</p>}
-
-      {[
-        { name: "name", placeholder: "Nombre" },
-        { name: "address", placeholder: "Dirección" },
-        { name: "phone", placeholder: "Teléfono" },
-        { name: "email", placeholder: "email" },
-        { name: "Contact", placeholder: "Contacto" },
-        { name: "CUIT", placeholder: "CUIT" },
-      ].map((field) => (
-        <input
-          key={field.name}
-          name={field.name}
-          value={supplier[field.name]}
-          onChange={handleChange}
-          placeholder={field.placeholder}
-          className="w-full border p-2"
-        />
-      ))}
-
-      <label className="flex items-center gap-2">
-        <input
-          type="checkbox"
-          name="isActive"
-          checked={supplier.isActive}
-          onChange={handleChange}
-        />
-        Activo
-      </label>
-
-      <div className="flex justify-end gap-2">
-        <button
-          type="button"
-          onClick={() => window.close()}
-          className="bg-gray-300 px-4 py-2 rounded"
-        >
-          Cancelar
-        </button>
-        <button
-          type="submit"
-          className="bg-blue-600 text-white px-4 py-2 rounded"
-        >
-          Guardar Proveedor
-        </button>
-      </div>
-    </form>
-  );
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4 p-6 max-w-xl mx-auto">
+            <h2 className="text-xl font-bold">{initialSupplier ? 'Editar Proveedor' : 'Nuevo Proveedor'}</h2>
+            {error && <p className="text-red-600">{error}</p>}
+            <input
+                name="firstName"
+                value={supplier.firstName}
+                onChange={handleChange}
+                placeholder="Nombre"
+                className="w-full border p-2"
+            />
+            <input
+                name="lastName"
+                value={supplier.lastName}
+                onChange={handleChange}
+                placeholder="Apellido"
+                className="w-full border p-2"
+            />
+            <input
+                name="email"
+                value={supplier.email}
+                onChange={handleChange}
+                placeholder="Email"
+                className="w-full border p-2"
+            />
+            <input
+                name="phone"
+                value={supplier.phone}
+                onChange={handleChange}
+                placeholder="Teléfono"
+                className="w-full border p-2"
+            />
+            <input
+                name="address"
+                value={supplier.address}
+                onChange={handleChange}
+                placeholder="Dirección"
+                className="w-full border p-2"
+            />
+            <label className="flex items-center gap-2">
+                <input
+                    type="checkbox"
+                    name="isActive"
+                    checked={supplier.isActive}
+                    onChange={handleChange}
+                />
+                Activo
+            </label>
+            <div className="flex justify-end gap-2">
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className="bg-gray-300 px-4 py-2 rounded"
+                >
+                    Cancelar
+                </button>
+                <button
+                    type="submit"
+                    disabled={loading}
+                    className="bg-blue-600 text-white px-4 py-2 rounded"
+                >
+                    {loading ? 'Guardando...' : 'Guardar Proveedor'}
+                </button>
+            </div>
+        </form>
+    );
 }


### PR DESCRIPTION
## Summary
- add GraphQL mutations for suppliers
- hook supplier mutations into schema
- implement supplier operations in frontend client
- add SupplierCreate form using GraphQL
- update Suppliers page to use new operations

## Testing
- `pytest`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68661b63be248323bfe031861f32757b