### PR TITLE
Align supplier pages with client UI

### DIFF
--- a/frontend/src/pages/SupplierCreate.jsx
+++ b/frontend/src/pages/SupplierCreate.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { supplierOperations } from "../utils/graphqlClient";
 
 export default function SupplierCreate({ onClose, onSave, supplier: initialSupplier = null }) {
@@ -16,13 +16,48 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
         provinceID: null,
         isActive: true,
     });
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState(null);
 
-    useState(() => {
+    const [formData, setFormData] = useState({
+        documentTypes: [],
+        countries: [],
+        provinces: []
+    });
+
+    const [error, setError] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [loadingForm, setLoadingForm] = useState(true);
+    const [isEdit, setIsEdit] = useState(false);
+
+    const loadFormData = useCallback(async () => {
+        try {
+            setLoadingForm(true);
+            const data = await supplierOperations.getSupplierFormData();
+            setFormData(data);
+            if (!isEdit && data.documentTypes.length > 0) {
+                setSupplier(prev => ({
+                    ...prev,
+                    docTypeID: data.documentTypes[0].DocTypeID,
+                    countryID: data.countries[0]?.CountryID || null,
+                    provinceID: data.provinces[0]?.ProvinceID || null,
+                }));
+            }
+        } catch (err) {
+            console.error("Error cargando datos del formulario:", err);
+            setError("Error cargando datos del formulario: " + err.message);
+        } finally {
+            setLoadingForm(false);
+        }
+    }, [isEdit]);
+
+    useEffect(() => {
+        loadFormData();
+    }, [loadFormData]);
+
+    useEffect(() => {
         if (initialSupplier) {
+            setIsEdit(true);
             setSupplier({
-                docTypeID: initialSupplier.DocTypeID,
+                docTypeID: parseInt(initialSupplier.DocTypeID) || null,
                 docNumber: initialSupplier.DocNumber || "",
                 firstName: initialSupplier.FirstName || "",
                 lastName: initialSupplier.LastName || "",
@@ -31,19 +66,30 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
                 address: initialSupplier.Address || "",
                 city: initialSupplier.City || "",
                 postalCode: initialSupplier.PostalCode || "",
-                countryID: initialSupplier.CountryID,
-                provinceID: initialSupplier.ProvinceID,
+                countryID: parseInt(initialSupplier.CountryID) || null,
+                provinceID: parseInt(initialSupplier.ProvinceID) || null,
                 isActive: initialSupplier.IsActive !== false,
             });
         }
-    }, []);
+    }, [initialSupplier]);
 
     const handleChange = (e) => {
         const { name, value, type, checked } = e.target;
-        setSupplier(prev => ({
-            ...prev,
-            [name]: type === "checkbox" ? checked : value,
-        }));
+        let processed;
+        if (type === "checkbox") processed = checked;
+        else if (name.includes("ID")) processed = parseInt(value) || null;
+        else processed = value;
+
+        setSupplier(prev => ({ ...prev, [name]: processed }));
+
+        if (name === "countryID") {
+            const provs = formData.provinces.filter(p => p.CountryID === parseInt(value));
+            setSupplier(prev => ({
+                ...prev,
+                countryID: parseInt(value),
+                provinceID: provs[0]?.ProvinceID || null,
+            }));
+        }
     };
 
     const handleSubmit = async (e) => {
@@ -52,13 +98,13 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
         setError(null);
         try {
             let result;
-            if (initialSupplier) {
+            if (isEdit) {
                 result = await supplierOperations.updateSupplier(initialSupplier.SupplierID, supplier);
             } else {
                 result = await supplierOperations.createSupplier(supplier);
             }
-            if (onSave) onSave(result);
-            if (onClose) onClose();
+            onSave && onSave(result);
+            onClose && onClose();
         } catch (err) {
             console.error("Error guardando proveedor:", err);
             setError(err.message);
@@ -67,70 +113,240 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
         }
     };
 
-    return (
-        <form onSubmit={handleSubmit} className="space-y-4 p-6 max-w-xl mx-auto">
-            <h2 className="text-xl font-bold">{initialSupplier ? 'Editar Proveedor' : 'Nuevo Proveedor'}</h2>
-            {error && <p className="text-red-600">{error}</p>}
-            <input
-                name="firstName"
-                value={supplier.firstName}
-                onChange={handleChange}
-                placeholder="Nombre"
-                className="w-full border p-2"
-            />
-            <input
-                name="lastName"
-                value={supplier.lastName}
-                onChange={handleChange}
-                placeholder="Apellido"
-                className="w-full border p-2"
-            />
-            <input
-                name="email"
-                value={supplier.email}
-                onChange={handleChange}
-                placeholder="Email"
-                className="w-full border p-2"
-            />
-            <input
-                name="phone"
-                value={supplier.phone}
-                onChange={handleChange}
-                placeholder="Teléfono"
-                className="w-full border p-2"
-            />
-            <input
-                name="address"
-                value={supplier.address}
-                onChange={handleChange}
-                placeholder="Dirección"
-                className="w-full border p-2"
-            />
-            <label className="flex items-center gap-2">
-                <input
-                    type="checkbox"
-                    name="isActive"
-                    checked={supplier.isActive}
-                    onChange={handleChange}
-                />
-                Activo
-            </label>
-            <div className="flex justify-end gap-2">
-                <button
-                    type="button"
-                    onClick={onClose}
-                    className="bg-gray-300 px-4 py-2 rounded"
-                >
-                    Cancelar
-                </button>
-                <button
-                    type="submit"
-                    disabled={loading}
-                    className="bg-blue-600 text-white px-4 py-2 rounded"
-                >
-                    {loading ? 'Guardando...' : 'Guardar Proveedor'}
-                </button>
+    const availableProvinces = formData.provinces.filter(p => p.CountryID === supplier.countryID);
+
+    if (loadingForm) {
+        return (
+            <div className="p-6 max-w-4xl mx-auto">
+                <div className="flex items-center justify-center h-64">
+                    <div className="text-center">
+                        <svg className="animate-spin h-8 w-8 text-blue-600 mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                        <p className="text-gray-600">Cargando formulario...</p>
+                    </div>
+                </div>
             </div>
-        </form>
+        );
+    }
+
+    return (
+        <div className="p-6 max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold mb-6">
+                {isEdit ? 'Editar Proveedor' : 'Nuevo Proveedor'}
+            </h2>
+
+            {error && (
+                <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg">
+                    <p className="text-red-600">{error}</p>
+                </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-6">
+                {/* Documento */}
+                <div className="bg-gray-50 p-4 rounded-lg">
+                    <h3 className="text-lg font-semibold mb-4">Información del Documento</h3>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">Tipo de Documento *</label>
+                            <select
+                                name="docTypeID"
+                                value={supplier.docTypeID || ''}
+                                onChange={handleChange}
+                                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                required
+                            >
+                                {formData.documentTypes.map(dt => (
+                                    <option key={dt.DocTypeID} value={dt.DocTypeID}>{dt.Name}</option>
+                                ))}
+                            </select>
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-2">Número de Documento</label>
+                            <input
+                                type="text"
+                                name="docNumber"
+                                value={supplier.docNumber}
+                                onChange={handleChange}
+                                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {/* Personal */}
+                <div className="bg-gray-50 p-4 rounded-lg">
+                    <h3 className="text-lg font-semibold mb-4">Información Personal</h3>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">Nombre *</label>
+                            <input
+                                type="text"
+                                name="firstName"
+                                value={supplier.firstName}
+                                onChange={handleChange}
+                                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                required
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-2">Apellido</label>
+                            <input
+                                type="text"
+                                name="lastName"
+                                value={supplier.lastName}
+                                onChange={handleChange}
+                                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {/* Contacto */}
+                <div className="bg-gray-50 p-4 rounded-lg">
+                    <h3 className="text-lg font-semibold mb-4">Información de Contacto</h3>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">Email</label>
+                            <input
+                                type="email"
+                                name="email"
+                                value={supplier.email}
+                                onChange={handleChange}
+                                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-2">Teléfono</label>
+                            <input
+                                type="tel"
+                                name="phone"
+                                value={supplier.phone}
+                                onChange={handleChange}
+                                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {/* Ubicación */}
+                <div className="bg-gray-50 p-4 rounded-lg">
+                    <h3 className="text-lg font-semibold mb-4">Información de Ubicación</h3>
+                    <div className="space-y-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">Dirección</label>
+                            <input
+                                type="text"
+                                name="address"
+                                value={supplier.address}
+                                onChange={handleChange}
+                                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                            />
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                            <div>
+                                <label className="block text-sm font-medium mb-2">País *</label>
+                                <select
+                                    name="countryID"
+                                    value={supplier.countryID || ''}
+                                    onChange={handleChange}
+                                    className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                    required
+                                >
+                                    {formData.countries.map(c => (
+                                        <option key={c.CountryID} value={c.CountryID}>{c.Name}</option>
+                                    ))}
+                                </select>
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium mb-2">Provincia *</label>
+                                <select
+                                    name="provinceID"
+                                    value={supplier.provinceID || ''}
+                                    onChange={handleChange}
+                                    className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                    required
+                                >
+                                    {availableProvinces.length > 0 ? (
+                                        availableProvinces.map(p => (
+                                            <option key={p.ProvinceID} value={p.ProvinceID}>{p.Name}</option>
+                                        ))
+                                    ) : (
+                                        <option value="">No hay provincias disponibles</option>
+                                    )}
+                                </select>
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium mb-2">Ciudad</label>
+                                <input
+                                    type="text"
+                                    name="city"
+                                    value={supplier.city}
+                                    onChange={handleChange}
+                                    className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                />
+                            </div>
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                                <label className="block text-sm font-medium mb-2">Código Postal</label>
+                                <input
+                                    type="text"
+                                    name="postalCode"
+                                    value={supplier.postalCode}
+                                    onChange={handleChange}
+                                    className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Activo */}
+                <div className="bg-gray-50 p-4 rounded-lg">
+                    <div className="mt-4">
+                        <label className="flex items-center space-x-3">
+                            <input
+                                type="checkbox"
+                                name="isActive"
+                                checked={supplier.isActive}
+                                onChange={handleChange}
+                                className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+                            />
+                            <span className="text-sm font-medium">Proveedor activo</span>
+                        </label>
+                    </div>
+                </div>
+
+                <div className="flex justify-end space-x-4 pt-6 border-t">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        disabled={loading}
+                        className="px-6 py-3 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                        Cancelar
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={loading || !supplier.firstName.trim()}
+                        className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center transition-colors"
+                    >
+                        {loading ? (
+                            <>
+                                <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                </svg>
+                                {isEdit ? 'Actualizando...' : 'Guardando...'}
+                            </>
+                        ) : (
+                            isEdit ? 'Actualizar Proveedor' : 'Guardar Proveedor'
+                        )}
+                    </button>
+                </div>
+            </form>
+        </div>
     );
 }

--- a/frontend/src/pages/Suppliers.jsx
+++ b/frontend/src/pages/Suppliers.jsx
@@ -1,103 +1,114 @@
 import { useEffect, useState } from "react";
-import {
-    PencilSquareIcon,
-    TrashIcon,
-    PlusIcon,
-} from "@heroicons/react/24/solid";
-import { supplierOperations } from "../utils/graphqlClient";
+import { supplierOperations, diagnosticGraphQL } from "../utils/graphqlClient";
 import SupplierCreate from "./SupplierCreate";
+import TableFilters from "../components/TableFilters";
+
+function SupplierDetails({ supplier, onClose }) {
+    if (!supplier) return null;
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+            <div className="bg-white rounded-lg max-w-lg w-full p-6 space-y-4">
+                <h2 className="text-xl font-bold">Detalles del Proveedor</h2>
+                <div className="space-y-1 text-sm">
+                    <p><strong>Nombre:</strong> {supplier.FirstName} {supplier.LastName}</p>
+                    <p><strong>Email:</strong> {supplier.Email || '—'}</p>
+                    <p><strong>Teléfono:</strong> {supplier.Phone || '—'}</p>
+                    <p><strong>Dirección:</strong> {supplier.Address || '—'}</p>
+                    <p><strong>Documento:</strong> {supplier.DocNumber || '—'}</p>
+                    <p><strong>Activo:</strong> {supplier.IsActive ? 'Sí' : 'No'}</p>
+                </div>
+                <div className="text-right mt-4">
+                    <button onClick={onClose} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Cerrar</button>
+                </div>
+            </div>
+        </div>
+    );
+}
 
 export default function Suppliers() {
+    const [allSuppliers, setAllSuppliers] = useState([]);
     const [suppliers, setSuppliers] = useState([]);
-    const [error, setError] = useState(null);
     const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [debugInfo, setDebugInfo] = useState(null);
+    const [showCreateModal, setShowCreateModal] = useState(false);
+    const [showFilters, setShowFilters] = useState(false);
+    const [selectedSupplier, setSelectedSupplier] = useState(null);
     const [editingSupplier, setEditingSupplier] = useState(null);
-    const [deletingSupplier, setDeletingSupplier] = useState(null);
-    const [showCreateForm, setShowCreateForm] = useState(false);
 
-    // Estado para filtros
-    const [searchTerm, setSearchTerm] = useState("");
-    const [filterActive, setFilterActive] = useState("all");
+    useEffect(() => {
+        loadSuppliers();
+    }, []);
 
-    const loadData = async () => {
+    const loadSuppliers = async () => {
         try {
             setLoading(true);
+            setError(null);
+            setDebugInfo("Cargando proveedores...");
             const data = await supplierOperations.getAllSuppliers();
+            setAllSuppliers(data);
             setSuppliers(data);
-
-        } catch (e) {
-            console.error("Error cargando proveedores:", e);
-            setError(e.message);
+            setDebugInfo(null);
+        } catch (err) {
+            console.error("Error cargando proveedores:", err);
+            setError(err.message);
+            setAllSuppliers([]);
+            setSuppliers([]);
         } finally {
             setLoading(false);
         }
     };
 
-    useEffect(() => {
-        loadData();
-    }, []);
-
-    const handleEditClick = (supplier) => {
-        setEditingSupplier({ ...supplier });
+    const runDiagnostic = async () => {
+        setDebugInfo("Ejecutando diagnóstico completo...");
+        const result = await diagnosticGraphQL();
+        setDebugInfo(result ? "Diagnóstico exitoso" : "Diagnóstico falló - revisa la consola");
     };
 
-    const handleDeleteClick = (supplier) => {
-        setDeletingSupplier(supplier);
+    const handleCreateSupplier = () => {
+        setShowCreateModal(true);
     };
 
-    const handleEditChange = (e) => {
-        const { name, value, type, checked } = e.target;
-        setEditingSupplier(prev => ({
-            ...prev,
-            [name]: type === "checkbox" ? checked : value,
-        }));
+    const handleEditSupplier = (supplier) => {
+        setEditingSupplier(supplier);
+        setShowCreateModal(true);
     };
 
-    const handleUpdate = async () => {
-        try {
-            const updated = await supplierOperations.updateSupplier(editingSupplier.SupplierID, editingSupplier);
-            setSuppliers(prev => prev.map(s =>
-                s.SupplierID === updated.SupplierID ? updated : s
-            ));
-            setEditingSupplier(null);
-        } catch (err) {
-            console.error("Error al actualizar:", err);
-            setError("Error al actualizar proveedor: " + err.message);
-        }
+    const handleViewDetails = (supplier) => {
+        setSelectedSupplier(supplier);
     };
 
-    const confirmDelete = async () => {
-        try {
-            await supplierOperations.deleteSupplier(deletingSupplier.SupplierID);
-            setSuppliers(prev => prev.filter(s => s.SupplierID !== deletingSupplier.SupplierID));
-            setDeletingSupplier(null);
-        } catch (e) {
-            console.error("Error al eliminar:", e);
-            setError("Error al eliminar proveedor: " + e.message);
-        }
+    const handleSupplierSaved = (newSupplier) => {
+        loadSuppliers();
+        setShowCreateModal(false);
+        setEditingSupplier(null);
     };
 
-    // Filtrar proveedores
-    const filteredSuppliers = suppliers.filter(supplier => {
-        const fullName = `${supplier.FirstName || ''} ${supplier.LastName || ''}`.toLowerCase();
-        const matchesSearch = !searchTerm ||
-            fullName.includes(searchTerm.toLowerCase()) ||
-            supplier.Email?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-            supplier.Phone?.includes(searchTerm);
-
-        const matchesActive = filterActive === "all" ||
-            (filterActive === "active" && supplier.IsActive) ||
-            (filterActive === "inactive" && !supplier.IsActive);
-
-        return matchesSearch && matchesActive;
-    });
+    const handleFilterChange = (filtered) => {
+        setSuppliers(filtered);
+    };
 
     if (loading) {
         return (
             <div className="p-6">
+                <div className="flex items-center justify-between mb-6">
+                    <h1 className="text-3xl font-bold text-gray-800">Proveedores</h1>
+                    <div className="flex items-center space-x-2">
+                        <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600"></div>
+                        <span className="text-blue-600">Cargando...</span>
+                    </div>
+                </div>
+                {debugInfo && (
+                    <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded">
+                        <p className="text-blue-800 text-sm">{debugInfo}</p>
+                    </div>
+                )}
                 <div className="animate-pulse">
-                    <div className="h-8 bg-gray-200 rounded mb-4"></div>
-                    <div className="h-64 bg-gray-200 rounded"></div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                        {[1,2,3,4,5,6].map(i => (
+                            <div key={i} className="bg-gray-200 h-32 rounded"></div>
+                        ))}
+                    </div>
                 </div>
             </div>
         );
@@ -105,261 +116,162 @@ export default function Suppliers() {
 
     return (
         <div className="p-6">
-            <div className="flex justify-between items-center mb-6">
-                <h1 className="text-2xl font-bold">Proveedores</h1>
-                <button
-                    onClick={() => setShowCreateForm(true)}
-                    className="bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center gap-2 hover:bg-blue-700"
-                >
-                    <PlusIcon className="w-5 h-5" />
-                    Nuevo Proveedor
-                </button>
-            </div>
-
-            {error && (
-                <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg">
-                    <p className="text-red-600">{error}</p>
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold text-gray-800">Proveedores</h1>
+                <div className="flex space-x-2">
                     <button
-                        onClick={() => setError(null)}
-                        className="text-red-800 underline text-sm"
+                        onClick={() => setShowFilters(!showFilters)}
+                        className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 transition-colors"
                     >
-                        Cerrar
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button
+                        onClick={runDiagnostic}
+                        className="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600 transition-colors"
+                    >
+                        Diagnóstico
+                    </button>
+                    <button
+                        onClick={loadSuppliers}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+                    >
+                        Recargar
+                    </button>
+                    <button
+                        onClick={handleCreateSupplier}
+                        className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition-colors"
+                    >
+                        Nuevo Proveedor
                     </button>
                 </div>
-            )}
+            </div>
 
-            {/* Filtros */}
-            <div className="mb-4 space-y-4">
-                <div className="flex gap-4 items-center">
-                    <input
-                        type="text"
-                        placeholder="Buscar por nombre, email o teléfono..."
-                        value={searchTerm}
-                        onChange={(e) => setSearchTerm(e.target.value)}
-                        className="flex-1 px-3 py-2 border border-gray-300 rounded-lg"
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters
+                        modelName="suppliers"
+                        data={allSuppliers}
+                        onFilterChange={handleFilterChange}
                     />
-                    <select
-                        value={filterActive}
-                        onChange={(e) => setFilterActive(e.target.value)}
-                        className="px-3 py-2 border border-gray-300 rounded-lg"
-                    >
-                        <option value="all">Todos</option>
-                        <option value="active">Activos</option>
-                        <option value="inactive">Inactivos</option>
-                    </select>
-                </div>
-                <div className="text-sm text-gray-600">
-                    Mostrando {filteredSuppliers.length} de {suppliers.length} proveedores
-                </div>
-            </div>
-
-            {/* Tabla de proveedores */}
-            <div className="bg-white rounded-lg shadow overflow-hidden">
-                <div className="overflow-x-auto">
-                    <table className="min-w-full divide-y divide-gray-200">
-                        <thead className="bg-gray-50">
-                            <tr>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Proveedor
-                                </th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Contacto
-                                </th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Dirección
-                                </th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Estado
-                                </th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Acciones
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody className="bg-white divide-y divide-gray-200">
-                            {filteredSuppliers.map((supplier) => (
-                                <tr key={supplier.SupplierID} className="hover:bg-gray-50">
-                                    <td className="px-6 py-4 whitespace-nowrap">
-                                        <div>
-                                            <div className="text-sm font-medium text-gray-900">
-                                                {supplier.FirstName} {supplier.LastName}
-                                            </div>
-                                            <div className="text-sm text-gray-500">
-                                                ID: {supplier.SupplierID}
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td className="px-6 py-4 whitespace-nowrap">
-                                        <div className="text-sm text-gray-900">
-                                            {supplier.Email || 'Sin email'}
-                                        </div>
-                                        <div className="text-sm text-gray-500">
-                                            {supplier.Phone || 'Sin teléfono'}
-                                        </div>
-                                    </td>
-                                    <td className="px-6 py-4 whitespace-nowrap">
-                                        <div className="text-sm text-gray-900">
-                                            {supplier.Address || 'Sin dirección'}
-                                        </div>
-                                    </td>
-                                    <td className="px-6 py-4 whitespace-nowrap">
-                                        <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${supplier.IsActive
-                                                ? 'bg-green-100 text-green-800'
-                                                : 'bg-red-100 text-red-800'
-                                            }`}>
-                                            {supplier.IsActive ? 'Activo' : 'Inactivo'}
-                                        </span>
-                                    </td>
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                                        <div className="flex space-x-2">
-                                            <button
-                                                onClick={() => handleEditClick(supplier)}
-                                                className="text-blue-600 hover:text-blue-800"
-                                            >
-                                                <PencilSquareIcon className="w-5 h-5" />
-                                            </button>
-                                            <button
-                                                onClick={() => handleDeleteClick(supplier)}
-                                                className="text-red-600 hover:text-red-800"
-                                            >
-                                                <TrashIcon className="w-5 h-5" />
-                                            </button>
-                                        </div>
-                                    </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-
-            {filteredSuppliers.length === 0 && (
-                <div className="text-center py-8 text-gray-500">
-                    {suppliers.length === 0 ? 'No hay proveedores registrados' : 'No se encontraron proveedores con los filtros aplicados'}
                 </div>
             )}
 
-            {/* Modal de edición */}
-            {editingSupplier && (
-                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-                    <div className="bg-white p-6 rounded-lg max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
-                        <h2 className="text-xl font-bold mb-4">Editar Proveedor</h2>
+            {debugInfo && (
+                <div className="mb-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                    <div className="flex items-center">
+                        <svg className="w-5 h-5 text-blue-600 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                            <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+                        </svg>
+                        <p className="text-blue-800 text-sm">{debugInfo}</p>
+                    </div>
+                </div>
+            )}
 
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <div className="md:col-span-2">
-                                <label className="block text-sm font-medium mb-1">Nombre</label>
-                                <input
-                                    type="text"
-                                    name="FirstName"
-                                    value={editingSupplier.FirstName || ''}
-                                    onChange={handleEditChange}
-                                    className="w-full border p-2 rounded"
-                                />
-                            </div>
-
-                            <div>
-                                <label className="block text-sm font-medium mb-1">Email</label>
-                                <input
-                                    type="email"
-                                    name="Email"
-                                    value={editingSupplier.Email || ''}
-                                    onChange={handleEditChange}
-                                    className="w-full border p-2 rounded"
-                                />
-                            </div>
-
-                            <div>
-                                <label className="block text-sm font-medium mb-1">Teléfono</label>
-                                <input
-                                    type="tel"
-                                    name="Phone"
-                                    value={editingSupplier.Phone || ''}
-                                    onChange={handleEditChange}
-                                    className="w-full border p-2 rounded"
-                                />
-                            </div>
-
-                            <div className="md:col-span-2">
-                                <label className="block text-sm font-medium mb-1">Dirección</label>
-                                <input
-                                    type="text"
-                                    name="Address"
-                                    value={editingSupplier.Address || ''}
-                                    onChange={handleEditChange}
-                                    className="w-full border p-2 rounded"
-                                />
-                            </div>
-
-                            <div className="md:col-span-2">
-                                <label className="flex items-center space-x-2">
-                                    <input
-                                        type="checkbox"
-                                        name="IsActive"
-                                        checked={editingSupplier.IsActive}
-                                        onChange={handleEditChange}
-                                    />
-                                    <span>Proveedor activo</span>
-                                </label>
-                            </div>
-                        </div>
-
-                        <div className="flex justify-end space-x-4 mt-6">
-                            <button
-                                onClick={() => setEditingSupplier(null)}
-                                className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
-                            >
-                                Cancelar
-                            </button>
-                            <button
-                                onClick={handleUpdate}
-                                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
-                            >
-                                Guardar Cambios
-                            </button>
+            {error && (
+                <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
+                    <div className="flex items-start">
+                        <svg className="w-5 h-5 text-red-600 mr-2 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+                            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+                        </svg>
+                        <div>
+                            <h4 className="text-red-800 font-semibold mb-1">Error cargando proveedores</h4>
+                            <p className="text-red-700 text-sm">{error}</p>
                         </div>
                     </div>
                 </div>
             )}
 
-            {/* Modal de confirmación de eliminación */}
-            {deletingSupplier && (
-                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-                    <div className="bg-white p-6 rounded-lg max-w-md w-full mx-4">
-                        <h2 className="text-xl font-bold mb-4">Confirmar Eliminación</h2>
-                        <p className="mb-4">
-                            ¿Estás seguro de que deseas eliminar al proveedor{" "}
-                            <strong>{deletingSupplier.FirstName}</strong>?
+            {!error && suppliers.length > 0 && (
+                <div>
+                    <div className="mb-4 flex items-center justify-between">
+                        <p className="text-gray-600">
+                            Mostrando {suppliers.length} proveedor{suppliers.length !== 1 ? 'es' : ''}
                         </p>
-                        <p className="text-sm text-gray-600 mb-6">
-                            Esta acción no se puede deshacer.
-                        </p>
-                        <div className="flex justify-end space-x-4">
-                            <button
-                                onClick={() => setDeletingSupplier(null)}
-                                className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
-                            >
-                                Cancelar
-                            </button>
-                            <button
-                                onClick={confirmDelete}
-                                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
-                            >
-                                Eliminar
-                            </button>
-                        </div>
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {suppliers.map(sup => (
+                            <div key={sup.SupplierID} className="bg-white rounded-lg shadow-md border border-gray-200 p-6 hover:shadow-lg transition-shadow">
+                                <div className="flex items-start justify-between mb-4">
+                                    <div>
+                                        <h3 className="text-lg font-semibold text-gray-900">
+                                            {sup.FirstName} {sup.LastName}
+                                        </h3>
+                                        <p className="text-sm text-gray-600">ID: {sup.SupplierID}</p>
+                                    </div>
+                                    <span className={`px-2 py-1 text-xs font-medium rounded-full ${sup.IsActive ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>{sup.IsActive ? 'Activo' : 'Inactivo'}</span>
+                                </div>
+                                <div className="space-y-2 text-sm">
+                                    {sup.Email && (
+                                        <div className="flex items-center">
+                                            <svg className="w-4 h-4 text-gray-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                                                <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+                                                <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+                                            </svg>
+                                            <span className="text-gray-700 truncate">{sup.Email}</span>
+                                        </div>
+                                    )}
+                                    {sup.Phone && (
+                                        <div className="flex items-center">
+                                            <svg className="w-4 h-4 text-gray-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                                                <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z" />
+                                            </svg>
+                                            <span className="text-gray-700">{sup.Phone}</span>
+                                        </div>
+                                    )}
+                                    {sup.Address && (
+                                        <div className="flex items-center">
+                                            <svg className="w-4 h-4 text-gray-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                                                <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
+                                            </svg>
+                                            <span className="text-gray-700 truncate">{sup.Address}</span>
+                                        </div>
+                                    )}
+                                    {sup.DocNumber && (
+                                        <div className="flex items-center">
+                                            <svg className="w-4 h-4 text-gray-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                                                <path fillRule="evenodd" d="M4 4a2 2 0 012-2h8a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 0v12h8V4H6z" clipRule="evenodd" />
+                                            </svg>
+                                            <span className="text-gray-700">Doc: {sup.DocNumber}</span>
+                                        </div>
+                                    )}
+                                </div>
+                                <div className="mt-4 pt-4 border-t border-gray-200 flex space-x-2">
+                                    <button onClick={() => handleViewDetails(sup)} className="flex-1 px-3 py-2 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 transition-colors">Ver Detalles</button>
+                                    <button onClick={() => handleEditSupplier(sup)} className="px-3 py-2 bg-gray-100 text-gray-700 text-sm rounded hover:bg-gray-200">Editar</button>
+                                </div>
+                            </div>
+                        ))}
                     </div>
                 </div>
             )}
 
-            {showCreateForm && (
+            {!error && !loading && suppliers.length === 0 && (
+                <div className="text-center py-12">
+                    <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                    </svg>
+                    <h3 className="mt-2 text-sm font-medium text-gray-900">No hay proveedores</h3>
+                    <p className="mt-1 text-sm text-gray-500">Comienza creando tu primer proveedor.</p>
+                    <div className="mt-6">
+                        <button onClick={handleCreateSupplier} className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700">Crear Primer Proveedor</button>
+                    </div>
+                </div>
+            )}
+
+            {showCreateModal && (
                 <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-                    <div className="bg-white rounded-lg max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+                    <div className="bg-white rounded-lg max-w-4xl w-full max-h-[90vh] overflow-y-auto">
                         <SupplierCreate
-                            onClose={() => setShowCreateForm(false)}
-                            onSave={(newSup) => setSuppliers(prev => [...prev, newSup])}
+                            onClose={() => { setShowCreateModal(false); setEditingSupplier(null); }}
+                            onSave={handleSupplierSaved}
+                            supplier={editingSupplier}
                         />
                     </div>
                 </div>
+            )}
+
+            {selectedSupplier && (
+                <SupplierDetails supplier={selectedSupplier} onClose={() => setSelectedSupplier(null)} />
             )}
         </div>
     );

--- a/frontend/src/utils/graphqlClient.js
+++ b/frontend/src/utils/graphqlClient.js
@@ -795,6 +795,22 @@ export const supplierOperations = {
         }
     },
 
+    // Obtener datos para formulario de proveedor
+    async getSupplierFormData() {
+        try {
+            // Reutilizamos la consulta de datos del formulario de clientes
+            const data = await clientOperations.getClientFormData();
+            return {
+                documentTypes: data.documentTypes,
+                countries: data.countries,
+                provinces: data.provinces,
+            };
+        } catch (error) {
+            console.error("Error obteniendo datos del formulario de proveedor:", error);
+            throw error;
+        }
+    },
+
     async createSupplier(supplierData) {
         try {
             const errors = supplierHelpers.validateSupplierData(supplierData);


### PR DESCRIPTION
## Summary
- update GraphQL client with a helper to fetch supplier form data
- redesign `SupplierCreate` to match the client creation form style
- revamp `Suppliers` listing using cards, filters and modals like in `Clients`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68661f9d3adc8323b863a989679b83f2