### PR TITLE
Add brand management via GraphQL

### DIFF
--- a/app/graphql/mutations/brands.py
+++ b/app/graphql/mutations/brands.py
@@ -1,0 +1,46 @@
+# app/graphql/mutations/brands.py
+import strawberry
+from typing import Optional
+from app.graphql.schemas.brands import BrandsCreate, BrandsUpdate, BrandsInDB
+from app.graphql.crud.brands import (
+    create_brands,
+    update_brands,
+    delete_brands,
+)
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+@strawberry.type
+class BrandsMutations:
+    @strawberry.mutation
+    def create_brand(self, info: Info, data: BrandsCreate) -> BrandsInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            new_brand = create_brands(db, data)
+            return obj_to_schema(BrandsInDB, new_brand)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_brand(self, info: Info, brandID: int, data: BrandsUpdate) -> Optional[BrandsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated_brand = update_brands(db, brandID, data)
+            if not updated_brand:
+                return None
+            return obj_to_schema(BrandsInDB, updated_brand)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_brand(self, info: Info, brandID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted_brand = delete_brands(db, brandID)
+            return deleted_brand is not None
+        finally:
+            db_gen.close()

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -50,6 +50,7 @@ from app.graphql.resolvers.warehouses import WarehousesQuery
 from app.graphql.resolvers.vendors import VendorsQuery
 from app.graphql.mutations.clients import ClientsMutations
 from app.graphql.mutations.suppliers import SuppliersMutations
+from app.graphql.mutations.brands import BrandsMutations
 
 # IMPORTANTE: Importar las clases de autenticación correctamente
 from app.graphql.resolvers.auth import AuthQuery
@@ -315,7 +316,7 @@ class Query(
 
 # MUTATION PRINCIPAL - COMPLETAMENTE CORREGIDO
 @strawberry.type
-class Mutation(ClientsMutations, SuppliersMutations):
+class Mutation(ClientsMutations, SuppliersMutations, BrandsMutations):
     """Mutaciones principales"""
     
     # ========== MUTACIONES DE AUTENTICACIÓN ==========

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Login from "./components/Login";
 import Dashboard from "./pages/Dashboard";
 import Clients from "./pages/Clients";
 import Suppliers from "./pages/Suppliers";
+import Brands from "./pages/Brands";
 import Documents from "./pages/Documents";
 import Layout from "./components/Layout";
 import RequireAuth from "./components/RequireAuth";
@@ -179,6 +180,7 @@ export default function App() {
                     <Route path="dashboard" element={<Dashboard />} />
                     <Route path="clients" element={<Clients />} />
                     <Route path="suppliers" element={<Suppliers />} />
+                    <Route path="brands" element={<Brands />} />
                     <Route path="documents" element={<Documents />} />
                     {/* Ruta fallback: todo lo desconocido a dashboard */}
                     <Route path="*" element={<Navigate to="/dashboard" replace />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -76,6 +76,7 @@ export default function Sidebar() {
       title: "Inventario",
       items: [
         { label: "Artículos", to: "/items" },
+        { label: "Marcas", to: "/brands" },
         { label: "Categorías", to: "/itemcategories" },
         { label: "Subcategorías", to: "/itemsubcategories" },
         { label: "Stock", to: "/itemstock" },

--- a/frontend/src/pages/BrandCreate.jsx
+++ b/frontend/src/pages/BrandCreate.jsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from "react";
+import { brandOperations } from "../utils/graphqlClient";
+
+export default function BrandCreate({ onClose, onSave, brand: initialBrand = null }) {
+    const [name, setName] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [isEdit, setIsEdit] = useState(false);
+
+    useEffect(() => {
+        if (initialBrand) {
+            setIsEdit(true);
+            setName(initialBrand.Name || "");
+        }
+    }, [initialBrand]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            let result;
+            if (isEdit) {
+                result = await brandOperations.updateBrand(initialBrand.BrandID, { Name: name });
+            } else {
+                result = await brandOperations.createBrand({ Name: name });
+            }
+            onSave && onSave(result);
+            onClose && onClose();
+        } catch (err) {
+            console.error("Error guardando marca:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Marca' : 'Nueva Marca'}</h2>
+            {error && <div className="text-red-600 mb-2">{error}</div>}
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-1">Nombre</label>
+                    <input
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        className="w-full border border-gray-300 p-2 rounded"
+                        required
+                    />
+                </div>
+                <div className="text-right">
+                    <button
+                        type="submit"
+                        disabled={loading || !name.trim()}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                        {loading ? 'Guardando...' : 'Guardar'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/pages/Brands.jsx
+++ b/frontend/src/pages/Brands.jsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { brandOperations } from "../utils/graphqlClient";
+import BrandCreate from "./BrandCreate";
+
+export default function Brands() {
+    const [brands, setBrands] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [showModal, setShowModal] = useState(false);
+    const [editingBrand, setEditingBrand] = useState(null);
+
+    useEffect(() => { loadBrands(); }, []);
+
+    const loadBrands = async () => {
+        try {
+            setLoading(true);
+            const data = await brandOperations.getAllBrands();
+            setBrands(data);
+        } catch (err) {
+            console.error("Error cargando marcas:", err);
+            setError(err.message);
+            setBrands([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleBrandSaved = () => {
+        loadBrands();
+        setShowModal(false);
+        setEditingBrand(null);
+    };
+
+    const handleCreate = () => {
+        setEditingBrand(null);
+        setShowModal(true);
+    };
+
+    const handleEdit = (brand) => {
+        setEditingBrand(brand);
+        setShowModal(true);
+    };
+
+    return (
+        <div className="p-6">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold text-gray-800">Marcas</h1>
+                <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                    Nueva Marca
+                </button>
+            </div>
+            {error && <div className="text-red-600 mb-4">{error}</div>}
+            {loading ? (
+                <div>Cargando...</div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {brands.map(br => (
+                        <div key={br.BrandID} className="bg-white rounded shadow p-4">
+                            <h3 className="text-lg font-semibold mb-2">{br.Name}</h3>
+                            <button onClick={() => handleEdit(br)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                        </div>
+                    ))}
+                </div>
+            )}
+            {showModal && (
+                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+                    <div className="bg-white rounded-lg max-w-md w-full">
+                        <BrandCreate
+                            onClose={() => { setShowModal(false); setEditingBrand(null); }}
+                            onSave={handleBrandSaved}
+                            brand={editingBrand}
+                        />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/utils/graphqlClient.js
+++ b/frontend/src/utils/graphqlClient.js
@@ -330,6 +330,24 @@ export const QUERIES = {
         }
     `,
 
+    // MARCAS
+    GET_ALL_BRANDS: `
+        query GetAllBrands {
+            allBrands {
+                BrandID
+                Name
+            }
+        }
+    `,
+    GET_BRAND_BY_ID: `
+        query GetBrandById($id: Int!) {
+            brandsById(id: $id) {
+                BrandID
+                Name
+            }
+        }
+    `,
+
     // DASHBOARD COMPLETO
     GET_DASHBOARD_DATA: `
         query GetDashboardData {
@@ -498,6 +516,29 @@ export const MUTATIONS = {
                 SupplierID
                 IsActive
             }
+        }
+    `,
+
+    // MARCAS
+    CREATE_BRAND: `
+        mutation CreateBrand($input: BrandsCreate!) {
+            createBrand(data: $input) {
+                BrandID
+                Name
+            }
+        }
+    `,
+    UPDATE_BRAND: `
+        mutation UpdateBrand($brandID: Int!, $input: BrandsUpdate!) {
+            updateBrand(brandID: $brandID, data: $input) {
+                BrandID
+                Name
+            }
+        }
+    `,
+    DELETE_BRAND: `
+        mutation DeleteBrand($brandID: Int!) {
+            deleteBrand(brandID: $brandID)
         }
     `
 };
@@ -867,6 +908,64 @@ export const supplierOperations = {
             return data.updateSupplier;
         } catch (error) {
             console.error("Error cambiando estado del proveedor:", error);
+            throw error;
+        }
+    }
+};
+
+// ===== FUNCIONES DE MARCAS =====
+export const brandOperations = {
+    async getAllBrands() {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_ALL_BRANDS);
+            return data.allBrands || [];
+        } catch (error) {
+            console.error("Error obteniendo marcas:", error);
+            throw error;
+        }
+    },
+
+    async getBrandById(id) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_BRAND_BY_ID, { id });
+            return data.brandsById;
+        } catch (error) {
+            console.error("Error obteniendo marca:", error);
+            throw error;
+        }
+    },
+
+    async createBrand(brandData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.CREATE_BRAND, {
+                input: brandData
+            });
+            return data.createBrand;
+        } catch (error) {
+            console.error("Error creando marca:", error);
+            throw error;
+        }
+    },
+
+    async updateBrand(id, brandData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_BRAND, {
+                brandID: id,
+                input: brandData
+            });
+            return data.updateBrand;
+        } catch (error) {
+            console.error("Error actualizando marca:", error);
+            throw error;
+        }
+    },
+
+    async deleteBrand(id) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.DELETE_BRAND, { brandID: id });
+            return data.deleteBrand;
+        } catch (error) {
+            console.error("Error eliminando marca:", error);
             throw error;
         }
     }


### PR DESCRIPTION
## Summary
- enable CRUD mutations for brands in backend
- expose brand operations in the GraphQL client
- add simple brand listing and create/edit pages
- link brands page in sidebar and router

## Testing
- `python -m py_compile app/graphql/mutations/brands.py app/graphql/schema.py`
- `node -e "require('./frontend/src/pages/Brands.jsx');"`

------
https://chatgpt.com/codex/tasks/task_e_686621b0278883238a9fc68909b5f4ca