### PR TITLE
Add brand active status and filters

### DIFF
--- a/app/graphql/resolvers/brands.py
+++ b/app/graphql/resolvers/brands.py
@@ -19,7 +19,8 @@ class BrandsQuery:
             for item in items:
                 data = {
                     'BrandID': int(item.__dict__['BrandID']),
-                    'Name': str(item.__dict__['Name'])
+                    'Name': str(item.__dict__['Name']),
+                    'IsActive': bool(item.__dict__.get('IsActive', True))
                 }
                 result.append(BrandsInDB(**data))
             return result
@@ -35,7 +36,8 @@ class BrandsQuery:
             if item:
                 data = {
                     'BrandID': int(item.__dict__['BrandID']),
-                    'Name': str(item.__dict__['Name'])
+                    'Name': str(item.__dict__['Name']),
+                    'IsActive': bool(item.__dict__.get('IsActive', True))
                 }
                 return BrandsInDB(**data)
             return None

--- a/app/graphql/schemas/brands.py
+++ b/app/graphql/schemas/brands.py
@@ -1,18 +1,22 @@
 # app/graphql/schemas/brands.py
 import strawberry
+from typing import Optional
 
 
 @strawberry.input
 class BrandsCreate:
     Name: str
+    IsActive: Optional[bool] = True
 
 
 @strawberry.input
 class BrandsUpdate:
-    Name: str
+    Name: Optional[str] = None
+    IsActive: Optional[bool] = None
 
 
 @strawberry.type
 class BrandsInDB:
     BrandID: int
     Name: str
+    IsActive: Optional[bool]

--- a/app/models/brands.py
+++ b/app/models/brands.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 from typing import List
 
-from sqlalchemy import Column, Integer, Unicode, Identity, PrimaryKeyConstraint
+from sqlalchemy import Column, Integer, Unicode, Boolean, Identity, PrimaryKeyConstraint, text
 from sqlalchemy.orm import Mapped, relationship
 from app.db import Base
 
@@ -21,6 +21,7 @@ class Brands(Base):
 
     BrandID = Column(Integer, Identity(start=1, increment=1), primary_key=True)
     Name = Column(Unicode(100, 'Modern_Spanish_CI_AS'))
+    IsActive = Column(Boolean, server_default=text('((1))'))
 
     # Relaciones
     items: Mapped[List['Items']] = relationship('Items', back_populates='brands_')

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -51,6 +51,7 @@ export default function Sidebar() {
       items: [
         { label: "Clientes", to: "/clients" },
         { label: "Proveedores", to: "/suppliers" },
+        { label: "Marcas", to: "/brands" },
       ],
     },
     {
@@ -76,7 +77,6 @@ export default function Sidebar() {
       title: "Inventario",
       items: [
         { label: "Artículos", to: "/items" },
-        { label: "Marcas", to: "/brands" },
         { label: "Categorías", to: "/itemcategories" },
         { label: "Subcategorías", to: "/itemsubcategories" },
         { label: "Stock", to: "/itemstock" },

--- a/frontend/src/pages/BrandCreate.jsx
+++ b/frontend/src/pages/BrandCreate.jsx
@@ -3,6 +3,7 @@ import { brandOperations } from "../utils/graphqlClient";
 
 export default function BrandCreate({ onClose, onSave, brand: initialBrand = null }) {
     const [name, setName] = useState("");
+    const [isActive, setIsActive] = useState(true);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
     const [isEdit, setIsEdit] = useState(false);
@@ -11,6 +12,7 @@ export default function BrandCreate({ onClose, onSave, brand: initialBrand = nul
         if (initialBrand) {
             setIsEdit(true);
             setName(initialBrand.Name || "");
+            setIsActive(initialBrand.IsActive !== false);
         }
     }, [initialBrand]);
 
@@ -21,9 +23,9 @@ export default function BrandCreate({ onClose, onSave, brand: initialBrand = nul
         try {
             let result;
             if (isEdit) {
-                result = await brandOperations.updateBrand(initialBrand.BrandID, { Name: name });
+                result = await brandOperations.updateBrand(initialBrand.BrandID, { Name: name, IsActive: isActive });
             } else {
-                result = await brandOperations.createBrand({ Name: name });
+                result = await brandOperations.createBrand({ Name: name, IsActive: isActive });
             }
             onSave && onSave(result);
             onClose && onClose();
@@ -49,6 +51,17 @@ export default function BrandCreate({ onClose, onSave, brand: initialBrand = nul
                         className="w-full border border-gray-300 p-2 rounded"
                         required
                     />
+                </div>
+                <div>
+                    <label className="inline-flex items-center mt-2">
+                        <input
+                            type="checkbox"
+                            className="mr-2"
+                            checked={isActive}
+                            onChange={(e) => setIsActive(e.target.checked)}
+                        />
+                        <span>Marca activa</span>
+                    </label>
                 </div>
                 <div className="text-right">
                     <button

--- a/frontend/src/pages/Brands.jsx
+++ b/frontend/src/pages/Brands.jsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from "react";
 import { brandOperations } from "../utils/graphqlClient";
 import BrandCreate from "./BrandCreate";
+import TableFilters from "../components/TableFilters";
 
 export default function Brands() {
+    const [allBrands, setAllBrands] = useState([]);
     const [brands, setBrands] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [showModal, setShowModal] = useState(false);
     const [editingBrand, setEditingBrand] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
 
     useEffect(() => { loadBrands(); }, []);
 
@@ -15,6 +18,7 @@ export default function Brands() {
         try {
             setLoading(true);
             const data = await brandOperations.getAllBrands();
+            setAllBrands(data);
             setBrands(data);
         } catch (err) {
             console.error("Error cargando marcas:", err);
@@ -36,6 +40,10 @@ export default function Brands() {
         setShowModal(true);
     };
 
+    const handleFilterChange = (filtered) => {
+        setBrands(filtered);
+    };
+
     const handleEdit = (brand) => {
         setEditingBrand(brand);
         setShowModal(true);
@@ -45,10 +53,33 @@ export default function Brands() {
         <div className="p-6">
             <div className="flex items-center justify-between mb-6">
                 <h1 className="text-3xl font-bold text-gray-800">Marcas</h1>
-                <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
-                    Nueva Marca
-                </button>
+                <div className="flex space-x-2">
+                    <button
+                        onClick={() => setShowFilters(!showFilters)}
+                        className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700"
+                    >
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button
+                        onClick={loadBrands}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                    >
+                        Recargar
+                    </button>
+                    <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                        Nueva Marca
+                    </button>
+                </div>
             </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters
+                        modelName="brands"
+                        data={allBrands}
+                        onFilterChange={handleFilterChange}
+                    />
+                </div>
+            )}
             {error && <div className="text-red-600 mb-4">{error}</div>}
             {loading ? (
                 <div>Cargando...</div>
@@ -57,6 +88,7 @@ export default function Brands() {
                     {brands.map(br => (
                         <div key={br.BrandID} className="bg-white rounded shadow p-4">
                             <h3 className="text-lg font-semibold mb-2">{br.Name}</h3>
+                            <p className="text-sm mb-2">Activo: {br.IsActive ? 'Sí' : 'No'}</p>
                             <button onClick={() => handleEdit(br)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
                         </div>
                     ))}

--- a/frontend/src/utils/graphqlClient.js
+++ b/frontend/src/utils/graphqlClient.js
@@ -336,6 +336,7 @@ export const QUERIES = {
             allBrands {
                 BrandID
                 Name
+                IsActive
             }
         }
     `,
@@ -344,6 +345,7 @@ export const QUERIES = {
             brandsById(id: $id) {
                 BrandID
                 Name
+                IsActive
             }
         }
     `,
@@ -525,6 +527,7 @@ export const MUTATIONS = {
             createBrand(data: $input) {
                 BrandID
                 Name
+                IsActive
             }
         }
     `,
@@ -533,6 +536,7 @@ export const MUTATIONS = {
             updateBrand(brandID: $brandID, data: $input) {
                 BrandID
                 Name
+                IsActive
             }
         }
     `,


### PR DESCRIPTION
## Summary
- add `IsActive` to brand model and schema
- include brand status in GraphQL resolvers and client queries
- allow editing brand active state in the form
- show active status and filters in brand list
- move Brands menu to **Archivo** section in sidebar

## Testing
- `npm run lint` *(fails: cannot find some variables, etc.)*
- `python -m py_compile $(git ls-files '*.py')` *(fails: unicode error in cache.py)*

------
https://chatgpt.com/codex/tasks/task_e_686637f88f888323a4d0fd19cfaf237d