### PR TITLE
Add CarBrands CRUD and sidebar entry

### DIFF
--- a/app/graphql/mutations/carbrands.py
+++ b/app/graphql/mutations/carbrands.py
@@ -1,0 +1,45 @@
+import strawberry
+from typing import Optional
+from app.graphql.schemas.carbrands import CarBrandsCreate, CarBrandsUpdate, CarBrandsInDB
+from app.graphql.crud.carbrands import (
+    create_carbrands,
+    update_carbrands,
+    delete_carbrands,
+)
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+@strawberry.type
+class CarBrandsMutations:
+    @strawberry.mutation
+    def create_carbrand(self, info: Info, data: CarBrandsCreate) -> CarBrandsInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            new_carbrand = create_carbrands(db, data)
+            return obj_to_schema(CarBrandsInDB, new_carbrand)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_carbrand(self, info: Info, carBrandID: int, data: CarBrandsUpdate) -> Optional[CarBrandsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated_carbrand = update_carbrands(db, carBrandID, data)
+            if not updated_carbrand:
+                return None
+            return obj_to_schema(CarBrandsInDB, updated_carbrand)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_carbrand(self, info: Info, carBrandID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_carbrands(db, carBrandID)
+            return deleted is not None
+        finally:
+            db_gen.close()

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -51,6 +51,7 @@ from app.graphql.resolvers.vendors import VendorsQuery
 from app.graphql.mutations.clients import ClientsMutations
 from app.graphql.mutations.suppliers import SuppliersMutations
 from app.graphql.mutations.brands import BrandsMutations
+from app.graphql.mutations.carbrands import CarBrandsMutations
 
 # IMPORTANTE: Importar las clases de autenticación correctamente
 from app.graphql.resolvers.auth import AuthQuery
@@ -316,7 +317,7 @@ class Query(
 
 # MUTATION PRINCIPAL - COMPLETAMENTE CORREGIDO
 @strawberry.type
-class Mutation(ClientsMutations, SuppliersMutations, BrandsMutations):
+class Mutation(ClientsMutations, SuppliersMutations, BrandsMutations, CarBrandsMutations):
     """Mutaciones principales"""
     
     # ========== MUTACIONES DE AUTENTICACIÓN ==========

--- a/app/utils/filter_schemas.py
+++ b/app/utils/filter_schemas.py
@@ -55,6 +55,10 @@ FILTER_SCHEMAS = {
         {"field": "Name", "label": "Nombre", "type": "text"},
         {"field": "IsActive", "label": "Activo", "type": "boolean"}
     ],
+    "carbrands": [
+        {"field": "CarBrandID", "label": "ID de marca de auto", "type": "number"},
+        {"field": "Name", "label": "Nombre", "type": "text"}
+    ],
     "countries": [
         {"field": "CountryID", "label": "ID de país", "type": "number"},
         {"field": "Name", "label": "Nombre", "type": "text"}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Dashboard from "./pages/Dashboard";
 import Clients from "./pages/Clients";
 import Suppliers from "./pages/Suppliers";
 import Brands from "./pages/Brands";
+import CarBrands from "./pages/CarBrands";
 import Documents from "./pages/Documents";
 import Layout from "./components/Layout";
 import RequireAuth from "./components/RequireAuth";
@@ -181,6 +182,7 @@ export default function App() {
                     <Route path="clients" element={<Clients />} />
                     <Route path="suppliers" element={<Suppliers />} />
                     <Route path="brands" element={<Brands />} />
+                    <Route path="carbrands" element={<CarBrands />} />
                     <Route path="documents" element={<Documents />} />
                     {/* Ruta fallback: todo lo desconocido a dashboard */}
                     <Route path="*" element={<Navigate to="/dashboard" replace />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -52,12 +52,12 @@ export default function Sidebar() {
         { label: "Clientes", to: "/clients" },
         { label: "Proveedores", to: "/suppliers" },
         { label: "Marcas", to: "/brands" },
+        { label: "Autos", to: "/carbrands" },
       ],
     },
     {
       title: "Vehículos",
       items: [
-        { label: "Marcas de auto", to: "/carbrands" },
         { label: "Modelos de auto", to: "/carmodels" },
         { label: "Autos", to: "/cars" },
       ],

--- a/frontend/src/pages/CarBrandCreate.jsx
+++ b/frontend/src/pages/CarBrandCreate.jsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from "react";
+import { carBrandOperations } from "../utils/graphqlClient";
+
+export default function CarBrandCreate({ onClose, onSave, carBrand: initialCarBrand = null }) {
+    const [name, setName] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [isEdit, setIsEdit] = useState(false);
+
+    useEffect(() => {
+        if (initialCarBrand) {
+            setIsEdit(true);
+            setName(initialCarBrand.Name || "");
+        }
+    }, [initialCarBrand]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            let result;
+            if (isEdit) {
+                result = await carBrandOperations.updateCarBrand(initialCarBrand.CarBrandID, { Name: name });
+            } else {
+                result = await carBrandOperations.createCarBrand({ Name: name });
+            }
+            onSave && onSave(result);
+            onClose && onClose();
+        } catch (err) {
+            console.error("Error guardando marca de auto:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Marca de Auto' : 'Nueva Marca de Auto'}</h2>
+            {error && <div className="text-red-600 mb-2">{error}</div>}
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-1">Nombre</label>
+                    <input
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        className="w-full border border-gray-300 p-2 rounded"
+                        required
+                    />
+                </div>
+                <div className="text-right">
+                    <button
+                        type="submit"
+                        disabled={loading || !name.trim()}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                        {loading ? 'Guardando...' : 'Guardar'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/pages/CarBrands.jsx
+++ b/frontend/src/pages/CarBrands.jsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { carBrandOperations } from "../utils/graphqlClient";
+import CarBrandCreate from "./CarBrandCreate";
+import TableFilters from "../components/TableFilters";
+
+export default function CarBrands() {
+    const [allCarBrands, setAllCarBrands] = useState([]);
+    const [carBrands, setCarBrands] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [showModal, setShowModal] = useState(false);
+    const [editingCarBrand, setEditingCarBrand] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
+
+    useEffect(() => { loadCarBrands(); }, []);
+
+    const loadCarBrands = async () => {
+        try {
+            setLoading(true);
+            const data = await carBrandOperations.getAllCarBrands();
+            setAllCarBrands(data);
+            setCarBrands(data);
+        } catch (err) {
+            console.error("Error cargando marcas de auto:", err);
+            setError(err.message);
+            setCarBrands([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleSaved = () => {
+        loadCarBrands();
+        setShowModal(false);
+        setEditingCarBrand(null);
+    };
+
+    const handleCreate = () => {
+        setEditingCarBrand(null);
+        setShowModal(true);
+    };
+
+    const handleFilterChange = (filtered) => {
+        setCarBrands(filtered);
+    };
+
+    const handleEdit = (cb) => {
+        setEditingCarBrand(cb);
+        setShowModal(true);
+    };
+
+    return (
+        <div className="p-6">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold text-gray-800">Marcas de Auto</h1>
+                <div className="flex space-x-2">
+                    <button
+                        onClick={() => setShowFilters(!showFilters)}
+                        className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700"
+                    >
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button
+                        onClick={loadCarBrands}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                    >
+                        Recargar
+                    </button>
+                    <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                        Nueva Marca
+                    </button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters
+                        modelName="carbrands"
+                        data={allCarBrands}
+                        onFilterChange={handleFilterChange}
+                    />
+                </div>
+            )}
+            {error && <div className="text-red-600 mb-4">{error}</div>}
+            {loading ? (
+                <div>Cargando...</div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {carBrands.map(cb => (
+                        <div key={cb.CarBrandID} className="bg-white rounded shadow p-4">
+                            <h3 className="text-lg font-semibold mb-2">{cb.Name}</h3>
+                            <button onClick={() => handleEdit(cb)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                        </div>
+                    ))}
+                </div>
+            )}
+            {showModal && (
+                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+                    <div className="bg-white rounded-lg max-w-md w-full">
+                        <CarBrandCreate
+                            onClose={() => { setShowModal(false); setEditingCarBrand(null); }}
+                            onSave={handleSaved}
+                            carBrand={editingCarBrand}
+                        />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/utils/graphqlClient.js
+++ b/frontend/src/utils/graphqlClient.js
@@ -350,6 +350,24 @@ export const QUERIES = {
         }
     `,
 
+    // MARCAS DE AUTO
+    GET_ALL_CARBRANDS: `
+        query GetAllCarBrands {
+            allCarbrands {
+                CarBrandID
+                Name
+            }
+        }
+    `,
+    GET_CARBRAND_BY_ID: `
+        query GetCarBrandById($id: Int!) {
+            carbrandsById(id: $id) {
+                CarBrandID
+                Name
+            }
+        }
+    `,
+
     // DASHBOARD COMPLETO
     GET_DASHBOARD_DATA: `
         query GetDashboardData {
@@ -543,6 +561,28 @@ export const MUTATIONS = {
     DELETE_BRAND: `
         mutation DeleteBrand($brandID: Int!) {
             deleteBrand(brandID: $brandID)
+        }
+    `,
+    // MARCAS DE AUTO
+    CREATE_CARBRAND: `
+        mutation CreateCarBrand($input: CarBrandsCreate!) {
+            createCarbrand(data: $input) {
+                CarBrandID
+                Name
+            }
+        }
+    `,
+    UPDATE_CARBRAND: `
+        mutation UpdateCarBrand($carBrandID: Int!, $input: CarBrandsUpdate!) {
+            updateCarbrand(carBrandID: $carBrandID, data: $input) {
+                CarBrandID
+                Name
+            }
+        }
+    `,
+    DELETE_CARBRAND: `
+        mutation DeleteCarBrand($carBrandID: Int!) {
+            deleteCarbrand(carBrandID: $carBrandID)
         }
     `
 };
@@ -969,6 +1009,65 @@ export const brandOperations = {
             return data.deleteBrand;
         } catch (error) {
             console.error("Error eliminando marca:", error);
+            throw error;
+        }
+    }
+};
+
+export const carBrandOperations = {
+    async getAllCarBrands() {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_ALL_CARBRANDS);
+            return data.allCarbrands || [];
+        } catch (error) {
+            console.error("Error obteniendo marcas de auto:", error);
+            throw error;
+        }
+    },
+
+    async getCarBrandById(id) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_CARBRAND_BY_ID, { id });
+            return data.carbrandsById;
+        } catch (error) {
+            console.error("Error obteniendo marca de auto:", error);
+            throw error;
+        }
+    },
+
+    async createCarBrand(carBrandData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.CREATE_CARBRAND, {
+                input: carBrandData
+            });
+            return data.createCarbrand;
+        } catch (error) {
+            console.error("Error creando marca de auto:", error);
+            throw error;
+        }
+    },
+
+    async updateCarBrand(id, carBrandData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_CARBRAND, {
+                carBrandID: id,
+                input: carBrandData
+            });
+            return data.updateCarbrand;
+        } catch (error) {
+            console.error("Error actualizando marca de auto:", error);
+            throw error;
+        }
+    },
+
+    async deleteCarBrand(id) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.DELETE_CARBRAND, {
+                carBrandID: id
+            });
+            return data.deleteCarbrand;
+        } catch (error) {
+            console.error("Error eliminando marca de auto:", error);
             throw error;
         }
     }


### PR DESCRIPTION
## Summary
- implement CarBrands mutations
- register CarBrands mutations in GraphQL schema
- add filters for carbrands
- expand GraphQL client with car brand operations
- add CarBrands pages and create form in frontend
- route & sidebar entry for carbrands

## Testing
- `pytest -q`
- `npm test --silent`
- `pyright` *(fails: many existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68663e263404832384ca069e5009123a