### PR TITLE
Implement SaleConditions CRUD

### DIFF
--- a/app/graphql/mutations/saleconditions.py
+++ b/app/graphql/mutations/saleconditions.py
@@ -1,0 +1,47 @@
+import strawberry
+from typing import Optional
+from app.graphql.schemas.saleconditions import (
+    SaleConditionsCreate,
+    SaleConditionsUpdate,
+    SaleConditionsInDB,
+)
+from app.graphql.crud.saleconditions import (
+    create_saleconditions,
+    update_saleconditions,
+    delete_saleconditions,
+)
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+@strawberry.type
+class SaleConditionsMutations:
+    @strawberry.mutation
+    def create_salecondition(self, info: Info, data: SaleConditionsCreate) -> SaleConditionsInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            obj = create_saleconditions(db, data)
+            return obj_to_schema(SaleConditionsInDB, obj)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_salecondition(self, info: Info, saleConditionID: int, data: SaleConditionsUpdate) -> Optional[SaleConditionsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated = update_saleconditions(db, saleConditionID, data)
+            return obj_to_schema(SaleConditionsInDB, updated) if updated else None
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_salecondition(self, info: Info, saleConditionID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_saleconditions(db, saleConditionID)
+            return deleted is not None
+        finally:
+            db_gen.close()

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -55,6 +55,7 @@ from app.graphql.mutations.carbrands import CarBrandsMutations
 from app.graphql.mutations.itemcategories import ItemCategoriesMutations
 from app.graphql.mutations.itemsubcategories import ItemSubcategoriesMutations
 from app.graphql.mutations.items import ItemsMutations
+from app.graphql.mutations.saleconditions import SaleConditionsMutations
 
 # IMPORTANTE: Importar las clases de autenticación correctamente
 from app.graphql.resolvers.auth import AuthQuery
@@ -320,7 +321,7 @@ class Query(
 
 # MUTATION PRINCIPAL - COMPLETAMENTE CORREGIDO
 @strawberry.type
-class Mutation(ClientsMutations, SuppliersMutations, BrandsMutations, CarBrandsMutations, ItemCategoriesMutations, ItemSubcategoriesMutations, ItemsMutations):
+class Mutation(ClientsMutations, SuppliersMutations, BrandsMutations, CarBrandsMutations, ItemCategoriesMutations, ItemSubcategoriesMutations, ItemsMutations, SaleConditionsMutations):
     """Mutaciones principales"""
     
     # ========== MUTACIONES DE AUTENTICACIÓN ==========

--- a/app/utils/filter_schemas.py
+++ b/app/utils/filter_schemas.py
@@ -102,6 +102,14 @@ FILTER_SCHEMAS = {
         {"field": "RoleID", "label": "ID de rol", "type": "number"},
         {"field": "Name", "label": "Nombre", "type": "text"}
     ],
+    "saleconditions": [
+        {"field": "SaleConditionID", "label": "ID de condición", "type": "number"},
+        {"field": "CreditCardID", "label": "Tarjeta", "type": "select", "relationModel": "CreditCard"},
+        {"field": "Name", "label": "Nombre", "type": "text"},
+        {"field": "DueDate", "label": "Vencimiento", "type": "text"},
+        {"field": "Surcharge", "label": "Recargo", "type": "number"},
+        {"field": "IsActive", "label": "Activo", "type": "boolean"}
+    ],
     "users": [
         {"field": "UserID", "label": "ID de usuario", "type": "number"},
         {"field": "Nickname", "label": "Usuario", "type": "text"},

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import CarBrands from "./pages/CarBrands";
 import ItemCategories from "./pages/ItemCategories";
 import ItemSubcategories from "./pages/ItemSubcategories";
 import Items from "./pages/Items";
+import SaleConditions from "./pages/SaleConditions";
 import Documents from "./pages/Documents";
 import Layout from "./components/Layout";
 import RequireAuth from "./components/RequireAuth";
@@ -185,6 +186,7 @@ export default function App() {
                     <Route path="clients" element={<Clients />} />
                     <Route path="suppliers" element={<Suppliers />} />
                     <Route path="brands" element={<Brands />} />
+                    <Route path="saleconditions" element={<SaleConditions />} />
                     <Route path="itemcategories" element={<ItemCategories />} />
                     <Route path="itemsubcategories" element={<ItemSubcategories />} />
                     <Route path="items" element={<Items />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -52,6 +52,7 @@ export default function Sidebar() {
         { label: "Clientes", to: "/clients" },
         { label: "Proveedores", to: "/suppliers" },
         { label: "Marcas", to: "/brands" },
+        { label: "Condiciones", to: "/saleconditions" },
         { label: "Autos", to: "/carbrands" },
         { label: "Categorías", to: "/itemcategories" },
         { label: "Subcategorías", to: "/itemsubcategories" },

--- a/frontend/src/pages/SaleConditionCreate.jsx
+++ b/frontend/src/pages/SaleConditionCreate.jsx
@@ -1,0 +1,112 @@
+import { useState, useEffect } from "react";
+import { saleConditionOperations } from "../utils/graphqlClient";
+
+export default function SaleConditionCreate({ onClose, onSave, saleCondition: initialSC = null }) {
+    const [name, setName] = useState("");
+    const [dueDate, setDueDate] = useState("");
+    const [surcharge, setSurcharge] = useState(0);
+    const [isActive, setIsActive] = useState(true);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [isEdit, setIsEdit] = useState(false);
+
+    useEffect(() => {
+        if (initialSC) {
+            setIsEdit(true);
+            setName(initialSC.Name || "");
+            setDueDate(initialSC.DueDate || "");
+            setSurcharge(initialSC.Surcharge || 0);
+            setIsActive(initialSC.IsActive !== false);
+        }
+    }, [initialSC]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            let result;
+            if (isEdit) {
+                result = await saleConditionOperations.updateSaleCondition(initialSC.SaleConditionID, {
+                    Name: name,
+                    DueDate: dueDate,
+                    Surcharge: parseFloat(surcharge),
+                    IsActive: isActive,
+                });
+            } else {
+                result = await saleConditionOperations.createSaleCondition({
+                    Name: name,
+                    DueDate: dueDate,
+                    Surcharge: parseFloat(surcharge),
+                    IsActive: isActive,
+                });
+            }
+            onSave && onSave(result);
+            onClose && onClose();
+        } catch (err) {
+            console.error("Error guardando condición:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Condición' : 'Nueva Condición'}</h2>
+            {error && <div className="text-red-600 mb-2">{error}</div>}
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-1">Nombre</label>
+                    <input
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        className="w-full border border-gray-300 p-2 rounded"
+                        required
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Vencimiento</label>
+                    <input
+                        type="date"
+                        value={dueDate}
+                        onChange={(e) => setDueDate(e.target.value)}
+                        className="w-full border border-gray-300 p-2 rounded"
+                        required
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Recargo</label>
+                    <input
+                        type="number"
+                        value={surcharge}
+                        onChange={(e) => setSurcharge(e.target.value)}
+                        className="w-full border border-gray-300 p-2 rounded"
+                        step="0.01"
+                    />
+                </div>
+                <div>
+                    <label className="inline-flex items-center mt-2">
+                        <input
+                            type="checkbox"
+                            className="mr-2"
+                            checked={isActive}
+                            onChange={(e) => setIsActive(e.target.checked)}
+                        />
+                        <span>Condición activa</span>
+                    </label>
+                </div>
+                <div className="text-right">
+                    <button
+                        type="submit"
+                        disabled={loading || !name.trim() || !dueDate}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                        {loading ? 'Guardando...' : 'Guardar'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/pages/SaleConditions.jsx
+++ b/frontend/src/pages/SaleConditions.jsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { saleConditionOperations } from "../utils/graphqlClient";
+import SaleConditionCreate from "./SaleConditionCreate";
+import TableFilters from "../components/TableFilters";
+
+export default function SaleConditions() {
+    const [allSaleConditions, setAllSaleConditions] = useState([]);
+    const [saleConditions, setSaleConditions] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [showModal, setShowModal] = useState(false);
+    const [editingSC, setEditingSC] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
+
+    useEffect(() => { loadSCs(); }, []);
+
+    const loadSCs = async () => {
+        try {
+            setLoading(true);
+            const data = await saleConditionOperations.getAllSaleConditions();
+            setAllSaleConditions(data);
+            setSaleConditions(data);
+        } catch (err) {
+            console.error("Error cargando condiciones:", err);
+            setError(err.message);
+            setSaleConditions([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleSaved = () => {
+        loadSCs();
+        setShowModal(false);
+        setEditingSC(null);
+    };
+
+    const handleCreate = () => {
+        setEditingSC(null);
+        setShowModal(true);
+    };
+
+    const handleFilterChange = (filtered) => {
+        setSaleConditions(filtered);
+    };
+
+    const handleEdit = (sc) => {
+        setEditingSC(sc);
+        setShowModal(true);
+    };
+
+    return (
+        <div className="p-6">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold text-gray-800">Condiciones de Venta</h1>
+                <div className="flex space-x-2">
+                    <button
+                        onClick={() => setShowFilters(!showFilters)}
+                        className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700"
+                    >
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button
+                        onClick={loadSCs}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                    >
+                        Recargar
+                    </button>
+                    <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                        Nueva Condición
+                    </button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters
+                        modelName="saleconditions"
+                        data={allSaleConditions}
+                        onFilterChange={handleFilterChange}
+                    />
+                </div>
+            )}
+            {error && <div className="text-red-600 mb-4">{error}</div>}
+            {loading ? (
+                <div>Cargando...</div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {saleConditions.map(sc => (
+                        <div key={sc.SaleConditionID} className="bg-white rounded shadow p-4">
+                            <h3 className="text-lg font-semibold mb-2">{sc.Name}</h3>
+                            <p className="text-sm mb-1">Vencimiento: {sc.DueDate}</p>
+                            <p className="text-sm mb-2">Activo: {sc.IsActive ? 'Sí' : 'No'}</p>
+                            <button onClick={() => handleEdit(sc)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                        </div>
+                    ))}
+                </div>
+            )}
+            {showModal && (
+                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+                    <div className="bg-white rounded-lg max-w-md w-full">
+                        <SaleConditionCreate
+                            onClose={() => { setShowModal(false); setEditingSC(null); }}
+                            onSave={handleSaved}
+                            saleCondition={editingSC}
+                        />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/utils/graphqlClient.js
+++ b/frontend/src/utils/graphqlClient.js
@@ -458,6 +458,30 @@ export const QUERIES = {
         }
     `,
 
+    // CONDICIONES DE VENTA
+    GET_ALL_SALECONDITIONS: `
+        query GetAllSaleConditions {
+            allSaleconditions {
+                SaleConditionID
+                Name
+                DueDate
+                Surcharge
+                IsActive
+            }
+        }
+    `,
+    GET_SALECONDITION_BY_ID: `
+        query GetSaleConditionById($id: Int!) {
+            saleconditionsById(id: $id) {
+                SaleConditionID
+                Name
+                DueDate
+                Surcharge
+                IsActive
+            }
+        }
+    `,
+
     // BÚSQUEDA DE CLIENTES
     SEARCH_CLIENTS: `
         query SearchClients($searchTerm: String!, $isActive: Boolean) {
@@ -691,6 +715,35 @@ export const MUTATIONS = {
     DELETE_CARBRAND: `
         mutation DeleteCarBrand($carBrandID: Int!) {
             deleteCarbrand(carBrandID: $carBrandID)
+        }
+    `,
+
+    // CONDICIONES DE VENTA
+    CREATE_SALECONDITION: `
+        mutation CreateSaleCondition($input: SaleConditionsCreate!) {
+            createSalecondition(data: $input) {
+                SaleConditionID
+                Name
+                DueDate
+                Surcharge
+                IsActive
+            }
+        }
+    `,
+    UPDATE_SALECONDITION: `
+        mutation UpdateSaleCondition($saleConditionID: Int!, $input: SaleConditionsUpdate!) {
+            updateSalecondition(saleConditionID: $saleConditionID, data: $input) {
+                SaleConditionID
+                Name
+                DueDate
+                Surcharge
+                IsActive
+            }
+        }
+    `,
+    DELETE_SALECONDITION: `
+        mutation DeleteSaleCondition($saleConditionID: Int!) {
+            deleteSalecondition(saleConditionID: $saleConditionID)
         }
     `,
 
@@ -1199,6 +1252,65 @@ export const carBrandOperations = {
             return data.deleteCarbrand;
         } catch (error) {
             console.error("Error eliminando marca de auto:", error);
+            throw error;
+        }
+    }
+};
+
+export const saleConditionOperations = {
+    async getAllSaleConditions() {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_ALL_SALECONDITIONS);
+            return data.allSaleconditions || [];
+        } catch (error) {
+            console.error("Error obteniendo condiciones de venta:", error);
+            throw error;
+        }
+    },
+
+    async getSaleConditionById(id) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_SALECONDITION_BY_ID, { id });
+            return data.saleconditionsById;
+        } catch (error) {
+            console.error("Error obteniendo condición de venta:", error);
+            throw error;
+        }
+    },
+
+    async createSaleCondition(scData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.CREATE_SALECONDITION, {
+                input: scData
+            });
+            return data.createSalecondition;
+        } catch (error) {
+            console.error("Error creando condición de venta:", error);
+            throw error;
+        }
+    },
+
+    async updateSaleCondition(id, scData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_SALECONDITION, {
+                saleConditionID: id,
+                input: scData
+            });
+            return data.updateSalecondition;
+        } catch (error) {
+            console.error("Error actualizando condición de venta:", error);
+            throw error;
+        }
+    },
+
+    async deleteSaleCondition(id) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.DELETE_SALECONDITION, {
+                saleConditionID: id
+            });
+            return data.deleteSalecondition;
+        } catch (error) {
+            console.error("Error eliminando condición de venta:", error);
             throw error;
         }
     }


### PR DESCRIPTION
## Summary
- define saleconditions filters
- add saleconditions GraphQL mutations
- expose saleconditions mutations in schema
- extend GraphQL client with salecondition queries/mutations
- add React pages for SaleConditions list & create/edit modal
- include new route and sidebar link

## Testing
- `python -m py_compile app/graphql/mutations/saleconditions.py`

------
https://chatgpt.com/codex/tasks/task_e_68664b74e4308323af893a0d0063067a