### PR TITLE
Use popup windows in management pages

### DIFF
--- a/frontend/src/pages/Brands.jsx
+++ b/frontend/src/pages/Brands.jsx
@@ -2,17 +2,26 @@ import { useEffect, useState } from "react";
 import { brandOperations } from "../utils/graphqlClient";
 import BrandCreate from "./BrandCreate";
 import TableFilters from "../components/TableFilters";
+import { openReactWindow } from "../utils/openReactWindow";
 
 export default function Brands() {
     const [allBrands, setAllBrands] = useState([]);
     const [brands, setBrands] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
-    const [showModal, setShowModal] = useState(false);
-    const [editingBrand, setEditingBrand] = useState(null);
     const [showFilters, setShowFilters] = useState(false);
 
     useEffect(() => { loadBrands(); }, []);
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-brands') {
+                loadBrands();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
+    }, []);
 
     const loadBrands = async () => {
         try {
@@ -31,13 +40,21 @@ export default function Brands() {
 
     const handleBrandSaved = () => {
         loadBrands();
-        setShowModal(false);
-        setEditingBrand(null);
     };
 
     const handleCreate = () => {
-        setEditingBrand(null);
-        setShowModal(true);
+        openReactWindow(
+            () => (
+                <BrandCreate
+                    onSave={() => {
+                        window.opener.postMessage('reload-brands', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Nueva Marca'
+        );
     };
 
     const handleFilterChange = (filtered) => {
@@ -45,8 +62,19 @@ export default function Brands() {
     };
 
     const handleEdit = (brand) => {
-        setEditingBrand(brand);
-        setShowModal(true);
+        openReactWindow(
+            () => (
+                <BrandCreate
+                    brand={brand}
+                    onSave={() => {
+                        window.opener.postMessage('reload-brands', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Editar Marca'
+        );
     };
 
     return (
@@ -92,17 +120,6 @@ export default function Brands() {
                             <button onClick={() => handleEdit(br)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
                         </div>
                     ))}
-                </div>
-            )}
-            {showModal && (
-                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-                    <div className="bg-white rounded-lg max-w-md w-full">
-                        <BrandCreate
-                            onClose={() => { setShowModal(false); setEditingBrand(null); }}
-                            onSave={handleBrandSaved}
-                            brand={editingBrand}
-                        />
-                    </div>
                 </div>
             )}
         </div>

--- a/frontend/src/pages/Clients.jsx
+++ b/frontend/src/pages/Clients.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { graphqlClient, QUERIES, diagnosticGraphQL } from "../utils/graphqlClient";
 import ClientCreate from "./ClientCreate";
+import { openReactWindow } from "../utils/openReactWindow";
 import TableFilters from "../components/TableFilters";
 
 // Modal simple para mostrar los datos del cliente seleccionado
@@ -37,13 +38,21 @@ export default function Clients() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [debugInfo, setDebugInfo] = useState(null);
-    const [showCreateModal, setShowCreateModal] = useState(false);
     const [showFilters, setShowFilters] = useState(false);
     const [selectedClient, setSelectedClient] = useState(null);
-    const [editingClient, setEditingClient] = useState(null);
 
     useEffect(() => {
         loadClients();
+    }, []);
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-clients') {
+                loadClients();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
     }, []);
 
     const loadClients = async () => {
@@ -100,24 +109,40 @@ export default function Clients() {
     };
 
     const handleCreateClient = () => {
-        setShowCreateModal(true);
+        openReactWindow(
+            () => (
+                <ClientCreate
+                    onSave={() => {
+                        window.opener.postMessage('reload-clients', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Nuevo Cliente'
+        );
     };
 
     const handleEditClient = (client) => {
-        setEditingClient(client);
-        setShowCreateModal(true);
+        openReactWindow(
+            () => (
+                <ClientCreate
+                    client={client}
+                    onSave={() => {
+                        window.opener.postMessage('reload-clients', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Editar Cliente'
+        );
     };
 
     const handleViewDetails = (client) => {
         setSelectedClient(client);
     };
 
-    const handleClientSaved = (newClient) => {
-        console.log('Cliente guardado:', newClient);
-        loadClients(); // Recargar la lista
-        setShowCreateModal(false);
-        setEditingClient(null);
-    };
 
     // El filtro ahora opera sobre allClients
     const handleFilterChange = (filteredClients) => {
@@ -352,18 +377,6 @@ export default function Clients() {
                 </div>
             )}
 
-            {/* Modal de crear cliente */}
-            {showCreateModal && (
-                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-                    <div className="bg-white rounded-lg max-w-4xl w-full max-h-[90vh] overflow-y-auto">
-                        <ClientCreate
-                            onClose={() => { setShowCreateModal(false); setEditingClient(null); }}
-                            onSave={handleClientSaved}
-                            client={editingClient}
-                        />
-                    </div>
-                </div>
-            )}
 
             {selectedClient && (
                 <ClientDetails client={selectedClient} onClose={() => setSelectedClient(null)} />

--- a/frontend/src/pages/CreditCards.jsx
+++ b/frontend/src/pages/CreditCards.jsx
@@ -2,17 +2,26 @@ import { useEffect, useState } from "react";
 import { creditCardOperations } from "../utils/graphqlClient";
 import CreditCardCreate from "./CreditCardCreate";
 import TableFilters from "../components/TableFilters";
+import { openReactWindow } from "../utils/openReactWindow";
 
 export default function CreditCards() {
     const [allCards, setAllCards] = useState([]);
     const [cards, setCards] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
-    const [showModal, setShowModal] = useState(false);
-    const [editingCard, setEditingCard] = useState(null);
     const [showFilters, setShowFilters] = useState(false);
 
     useEffect(() => { loadCards(); }, []);
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-creditcards') {
+                loadCards();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
+    }, []);
 
     const loadCards = async () => {
         try {
@@ -30,13 +39,21 @@ export default function CreditCards() {
 
     const handleSaved = () => {
         loadCards();
-        setShowModal(false);
-        setEditingCard(null);
     };
 
     const handleCreate = () => {
-        setEditingCard(null);
-        setShowModal(true);
+        openReactWindow(
+            () => (
+                <CreditCardCreate
+                    onSave={() => {
+                        window.opener.postMessage('reload-creditcards', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Nueva Tarjeta'
+        );
     };
 
     const handleFilterChange = (filtered) => {
@@ -44,8 +61,19 @@ export default function CreditCards() {
     };
 
     const handleEdit = (card) => {
-        setEditingCard(card);
-        setShowModal(true);
+        openReactWindow(
+            () => (
+                <CreditCardCreate
+                    card={card}
+                    onSave={() => {
+                        window.opener.postMessage('reload-creditcards', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Editar Tarjeta'
+        );
     };
 
     return (
@@ -93,17 +121,6 @@ export default function CreditCards() {
                             <button onClick={() => handleEdit(c)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
                         </div>
                     ))}
-                </div>
-            )}
-            {showModal && (
-                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-                    <div className="bg-white rounded-lg max-w-md w-full">
-                        <CreditCardCreate
-                            onClose={() => { setShowModal(false); setEditingCard(null); }}
-                            onSave={handleSaved}
-                            card={editingCard}
-                        />
-                    </div>
                 </div>
             )}
         </div>

--- a/frontend/src/pages/ItemCategories.jsx
+++ b/frontend/src/pages/ItemCategories.jsx
@@ -2,17 +2,26 @@ import { useEffect, useState } from "react";
 import { itemCategoryOperations } from "../utils/graphqlClient";
 import ItemCategoryCreate from "./ItemCategoryCreate";
 import TableFilters from "../components/TableFilters";
+import { openReactWindow } from "../utils/openReactWindow";
 
 export default function ItemCategories() {
     const [allCategories, setAllCategories] = useState([]);
     const [categories, setCategories] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
-    const [showModal, setShowModal] = useState(false);
-    const [editingCategory, setEditingCategory] = useState(null);
     const [showFilters, setShowFilters] = useState(false);
 
     useEffect(() => { loadCategories(); }, []);
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-itemcategories') {
+                loadCategories();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
+    }, []);
 
     const loadCategories = async () => {
         try {
@@ -31,13 +40,21 @@ export default function ItemCategories() {
 
     const handleCategorySaved = () => {
         loadCategories();
-        setShowModal(false);
-        setEditingCategory(null);
     };
 
     const handleCreate = () => {
-        setEditingCategory(null);
-        setShowModal(true);
+        openReactWindow(
+            () => (
+                <ItemCategoryCreate
+                    onSave={() => {
+                        window.opener.postMessage('reload-itemcategories', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Nueva Categoría'
+        );
     };
 
     const handleFilterChange = (filtered) => {
@@ -45,8 +62,19 @@ export default function ItemCategories() {
     };
 
     const handleEdit = (category) => {
-        setEditingCategory(category);
-        setShowModal(true);
+        openReactWindow(
+            () => (
+                <ItemCategoryCreate
+                    category={category}
+                    onSave={() => {
+                        window.opener.postMessage('reload-itemcategories', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Editar Categoría'
+        );
     };
 
     return (
@@ -91,17 +119,6 @@ export default function ItemCategories() {
                             <button onClick={() => handleEdit(cat)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
                         </div>
                     ))}
-                </div>
-            )}
-            {showModal && (
-                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-                    <div className="bg-white rounded-lg max-w-md w-full">
-                        <ItemCategoryCreate
-                            onClose={() => { setShowModal(false); setEditingCategory(null); }}
-                            onSave={handleCategorySaved}
-                            category={editingCategory}
-                        />
-                    </div>
                 </div>
             )}
         </div>

--- a/frontend/src/pages/Items.jsx
+++ b/frontend/src/pages/Items.jsx
@@ -2,17 +2,26 @@ import { useEffect, useState } from "react";
 import { itemOperations } from "../utils/graphqlClient";
 import ItemCreate from "./ItemCreate";
 import TableFilters from "../components/TableFilters";
+import { openReactWindow } from "../utils/openReactWindow";
 
 export default function Items() {
     const [allItems, setAllItems] = useState([]);
     const [items, setItems] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
-    const [showModal, setShowModal] = useState(false);
-    const [editingItem, setEditingItem] = useState(null);
     const [showFilters, setShowFilters] = useState(false);
 
     useEffect(() => { loadItems(); }, []);
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-items') {
+                loadItems();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
+    }, []);
 
     const loadItems = async () => {
         try {
@@ -31,13 +40,21 @@ export default function Items() {
 
     const handleItemSaved = () => {
         loadItems();
-        setShowModal(false);
-        setEditingItem(null);
     };
 
     const handleCreate = () => {
-        setEditingItem(null);
-        setShowModal(true);
+        openReactWindow(
+            () => (
+                <ItemCreate
+                    onSave={() => {
+                        window.opener.postMessage('reload-items', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Nuevo Ítem'
+        );
     };
 
     const handleFilterChange = (filtered) => {
@@ -45,8 +62,19 @@ export default function Items() {
     };
 
     const handleEdit = (item) => {
-        setEditingItem(item);
-        setShowModal(true);
+        openReactWindow(
+            () => (
+                <ItemCreate
+                    item={item}
+                    onSave={() => {
+                        window.opener.postMessage('reload-items', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Editar Ítem'
+        );
     };
 
     return (
@@ -92,17 +120,6 @@ export default function Items() {
                             <button onClick={() => handleEdit(it)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
                         </div>
                     ))}
-                </div>
-            )}
-            {showModal && (
-                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-                    <div className="bg-white rounded-lg max-w-md w-full">
-                        <ItemCreate
-                            onClose={() => { setShowModal(false); setEditingItem(null); }}
-                            onSave={handleItemSaved}
-                            item={editingItem}
-                        />
-                    </div>
                 </div>
             )}
         </div>

--- a/frontend/src/pages/SaleConditions.jsx
+++ b/frontend/src/pages/SaleConditions.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { saleConditionOperations, creditCardOperations, creditCardGroupOperations } from "../utils/graphqlClient";
 import SaleConditionCreate from "./SaleConditionCreate";
 import TableFilters from "../components/TableFilters";
+import { openReactWindow } from "../utils/openReactWindow";
 
 export default function SaleConditions() {
     const [allSaleConditions, setAllSaleConditions] = useState([]);
@@ -10,11 +11,19 @@ export default function SaleConditions() {
     const [groups, setGroups] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
-    const [showModal, setShowModal] = useState(false);
-    const [editingSC, setEditingSC] = useState(null);
     const [showFilters, setShowFilters] = useState(false);
 
     useEffect(() => { loadSCs(); }, []);
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-saleconditions') {
+                loadSCs();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
+    }, []);
 
     const loadSCs = async () => {
         try {
@@ -39,13 +48,23 @@ export default function SaleConditions() {
 
     const handleSaved = () => {
         loadSCs();
-        setShowModal(false);
-        setEditingSC(null);
     };
 
     const handleCreate = () => {
-        setEditingSC(null);
-        setShowModal(true);
+        openReactWindow(
+            () => (
+                <SaleConditionCreate
+                    cards={cards}
+                    groups={groups}
+                    onSave={() => {
+                        window.opener.postMessage('reload-saleconditions', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Nueva Condición'
+        );
     };
 
     const handleFilterChange = (filtered) => {
@@ -53,8 +72,21 @@ export default function SaleConditions() {
     };
 
     const handleEdit = (sc) => {
-        setEditingSC(sc);
-        setShowModal(true);
+        openReactWindow(
+            () => (
+                <SaleConditionCreate
+                    saleCondition={sc}
+                    cards={cards}
+                    groups={groups}
+                    onSave={() => {
+                        window.opener.postMessage('reload-saleconditions', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Editar Condición'
+        );
     };
 
     return (
@@ -109,17 +141,6 @@ export default function SaleConditions() {
                             </div>
                         );
                     })}
-                </div>
-            )}
-            {showModal && (
-                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-                    <div className="bg-white rounded-lg max-w-md w-full">
-                        <SaleConditionCreate
-                            onClose={() => { setShowModal(false); setEditingSC(null); }}
-                            onSave={handleSaved}
-                            saleCondition={editingSC}
-                        />
-                    </div>
                 </div>
             )}
         </div>

--- a/frontend/src/pages/Suppliers.jsx
+++ b/frontend/src/pages/Suppliers.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { graphqlClient, QUERIES, diagnosticGraphQL } from "../utils/graphqlClient";
 import SupplierCreate from "./SupplierCreate";
 import TableFilters from "../components/TableFilters";
+import { openReactWindow } from "../utils/openReactWindow";
 
 function SupplierDetails({ supplier, onClose }) {
     if (!supplier) return null;
@@ -33,13 +34,21 @@ export default function Suppliers() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [debugInfo, setDebugInfo] = useState(null);
-    const [showCreateModal, setShowCreateModal] = useState(false);
     const [showFilters, setShowFilters] = useState(false);
     const [selectedSupplier, setSelectedSupplier] = useState(null);
-    const [editingSupplier, setEditingSupplier] = useState(null);
 
     useEffect(() => {
         loadSuppliers();
+    }, []);
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-suppliers') {
+                loadSuppliers();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
     }, []);
 
     const loadSuppliers = async () => {
@@ -80,22 +89,38 @@ export default function Suppliers() {
     };
 
     const handleCreateSupplier = () => {
-        setShowCreateModal(true);
+        openReactWindow(
+            () => (
+                <SupplierCreate
+                    onSave={() => {
+                        window.opener.postMessage('reload-suppliers', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Nuevo Proveedor'
+        );
     };
 
     const handleEditSupplier = (supplier) => {
-        setEditingSupplier(supplier);
-        setShowCreateModal(true);
+        openReactWindow(
+            () => (
+                <SupplierCreate
+                    supplier={supplier}
+                    onSave={() => {
+                        window.opener.postMessage('reload-suppliers', '*');
+                        window.close();
+                    }}
+                    onClose={() => window.close()}
+                />
+            ),
+            'Editar Proveedor'
+        );
     };
 
     const handleViewDetails = (supplier) => {
         setSelectedSupplier(supplier);
-    };
-
-    const handleSupplierSaved = () => {
-        loadSuppliers();
-        setShowCreateModal(false);
-        setEditingSupplier(null);
     };
 
     const handleFilterChange = (filtered) => {
@@ -249,17 +274,6 @@ export default function Suppliers() {
                         <button onClick={handleCreateSupplier} className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700">
                             Crear Primer Proveedor
                         </button>
-                    </div>
-                </div>
-            )}
-            {showCreateModal && (
-                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-                    <div className="bg-white rounded-lg max-w-4xl w-full max-h-[90vh] overflow-y-auto">
-                        <SupplierCreate
-                            onClose={() => { setShowCreateModal(false); setEditingSupplier(null); }}
-                            onSave={handleSupplierSaved}
-                            supplier={editingSupplier}
-                        />
                     </div>
                 </div>
             )}


### PR DESCRIPTION
## Summary
- open popup windows for create/edit pages
- listen for `postMessage` events to refresh lists
- drop modal logic from pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686864d849b88323bb1655bdb15fc2f8