### PR TITLE
Read DB URL from environment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,27 @@
+# LubricentroDB Configuration
+ENVIRONMENT=production
+DEBUG=False
+
+# Database
+SQLALCHEMY_DATABASE_URL=mssql+pyodbc://sa:Ladeda78@127.0.0.1/LubricentroDB2?driver=ODBC+Driver+17+for+SQL+Server
+
+# JWT
+SECRET_KEY=lvCExuRie_iGmnAcbsyvMODcNWbPuFOmTmHGo77t4rE
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=300
+
+# CORS
+ALLOWED_ORIGINS=http://localhost:3000,https://yourdomain.com
+
+# Cache
+CACHE_TTL_STATIC=3600
+CACHE_TTL_DYNAMIC=300
+
+# Rate Limiting
+RATE_LIMIT_REQUESTS=100
+RATE_LIMIT_WINDOW=60
+
+# Logging
+LOG_LEVEL=INFO
+ENABLE_METRICS=True
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.db
 node_modules/
 .env.*
+!.env.template

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
+# PERPGSQLVS
 
+This repository contains a FastAPI application together with a small React frontend.
+
+## Configuration
+
+The backend reads its settings from environment variables. You can copy `.env.template` to `.env` and adjust the values. The most important variables are:
+
+- `SQLALCHEMY_DATABASE_URL` – SQLAlchemy connection string for the database.
+- `ENVIRONMENT` – set to `development`, `testing` or `production`.
+- `DEBUG` – enables debug mode when `true`.
+- `SECRET_KEY` – JWT secret key.
+
+Any variable present in `.env.template` can be configured in the same way.
+
+## Running locally
+
+1. Install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the backend:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+See `Como iniciar.txt` for additional development tips.

--- a/app/db.py
+++ b/app/db.py
@@ -1,8 +1,12 @@
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-SQLALCHEMY_DATABASE_URL = "mssql+pyodbc://sa:Ladeda78@127.0.0.1/LubricentroDB2?driver=ODBC+Driver+17+for+SQL+Server"
+SQLALCHEMY_DATABASE_URL = os.getenv(
+    "SQLALCHEMY_DATABASE_URL",
+    "mssql+pyodbc://sa:Ladeda78@127.0.0.1/LubricentroDB2?driver=ODBC+Driver+17+for+SQL+Server",
+)
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()

--- a/deploy.py
+++ b/deploy.py
@@ -178,7 +178,7 @@ ENVIRONMENT=production
 DEBUG=False
 
 # Database
-DATABASE_URL=mssql+pyodbc://sa:Ladeda78@127.0.0.1/LubricentroDB2?driver=ODBC+Driver+17+for+SQL+Server
+SQLALCHEMY_DATABASE_URL=mssql+pyodbc://sa:Ladeda78@127.0.0.1/LubricentroDB2?driver=ODBC+Driver+17+for+SQL+Server
 
 # JWT
 SECRET_KEY=lvCExuRie_iGmnAcbsyvMODcNWbPuFOmTmHGo77t4rE


### PR DESCRIPTION
## Summary
- load database URL from `SQLALCHEMY_DATABASE_URL`
- update deploy script and provide `.env.template`
- document environment variables

## Testing
- `python -m py_compile app/db.py deploy.py app/main.py app/auth.py app/config.py`

------
https://chatgpt.com/codex/tasks/task_e_6869293b1ff883238c944107c10d13eb