### PR TITLE
Add car models and cars management

### DIFF
--- a/app/graphql/mutations/carmodels.py
+++ b/app/graphql/mutations/carmodels.py
@@ -1,0 +1,45 @@
+import strawberry
+from typing import Optional
+from app.graphql.schemas.carmodels import CarModelsCreate, CarModelsUpdate, CarModelsInDB
+from app.graphql.crud.carmodels import (
+    create_carmodels,
+    update_carmodels,
+    delete_carmodels,
+)
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+@strawberry.type
+class CarModelsMutations:
+    @strawberry.mutation
+    def create_carmodel(self, info: Info, data: CarModelsCreate) -> CarModelsInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            new_obj = create_carmodels(db, data)
+            return obj_to_schema(CarModelsInDB, new_obj)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_carmodel(self, info: Info, carModelID: int, data: CarModelsUpdate) -> Optional[CarModelsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated = update_carmodels(db, carModelID, data)
+            if not updated:
+                return None
+            return obj_to_schema(CarModelsInDB, updated)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_carmodel(self, info: Info, carModelID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_carmodels(db, carModelID)
+            return deleted is not None
+        finally:
+            db_gen.close()

--- a/app/graphql/mutations/cars.py
+++ b/app/graphql/mutations/cars.py
@@ -1,0 +1,45 @@
+import strawberry
+from typing import Optional
+from app.graphql.schemas.cars import CarsCreate, CarsUpdate, CarsInDB
+from app.graphql.crud.cars import (
+    create_cars,
+    update_cars,
+    delete_cars,
+)
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+@strawberry.type
+class CarsMutations:
+    @strawberry.mutation
+    def create_car(self, info: Info, data: CarsCreate) -> CarsInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            new_obj = create_cars(db, data)
+            return obj_to_schema(CarsInDB, new_obj)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_car(self, info: Info, carID: int, data: CarsUpdate) -> Optional[CarsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated = update_cars(db, carID, data)
+            if not updated:
+                return None
+            return obj_to_schema(CarsInDB, updated)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_car(self, info: Info, carID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_cars(db, carID)
+            return deleted is not None
+        finally:
+            db_gen.close()

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -58,6 +58,8 @@ from app.graphql.mutations.items import ItemsMutations
 from app.graphql.mutations.saleconditions import SaleConditionsMutations
 from app.graphql.mutations.creditcardgroups import CreditCardGroupsMutations
 from app.graphql.mutations.creditcards import CreditCardsMutations
+from app.graphql.mutations.carmodels import CarModelsMutations
+from app.graphql.mutations.cars import CarsMutations
 
 # IMPORTANTE: Importar las clases de autenticación correctamente
 from app.graphql.resolvers.auth import AuthQuery
@@ -323,7 +325,20 @@ class Query(
 
 # MUTATION PRINCIPAL - COMPLETAMENTE CORREGIDO
 @strawberry.type
-class Mutation(ClientsMutations, SuppliersMutations, BrandsMutations, CarBrandsMutations, ItemCategoriesMutations, ItemSubcategoriesMutations, ItemsMutations, SaleConditionsMutations, CreditCardGroupsMutations, CreditCardsMutations):
+class Mutation(
+    ClientsMutations,
+    SuppliersMutations,
+    BrandsMutations,
+    CarBrandsMutations,
+    CarModelsMutations,
+    CarsMutations,
+    ItemCategoriesMutations,
+    ItemSubcategoriesMutations,
+    ItemsMutations,
+    SaleConditionsMutations,
+    CreditCardGroupsMutations,
+    CreditCardsMutations,
+):
     """Mutaciones principales"""
     
     # ========== MUTACIONES DE AUTENTICACIÓN ==========

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,8 @@ import Clients from "./pages/Clients";
 import Suppliers from "./pages/Suppliers";
 import Brands from "./pages/Brands";
 import CarBrands from "./pages/CarBrands";
+import CarModels from "./pages/CarModels";
+import Cars from "./pages/Cars";
 import ItemCategories from "./pages/ItemCategories";
 import ItemSubcategories from "./pages/ItemSubcategories";
 import Items from "./pages/Items";
@@ -195,6 +197,8 @@ export default function App() {
                     <Route path="itemsubcategories" element={<ItemSubcategories />} />
                     <Route path="items" element={<Items />} />
                     <Route path="carbrands" element={<CarBrands />} />
+                    <Route path="carmodels" element={<CarModels />} />
+                    <Route path="cars" element={<Cars />} />
                     <Route path="documents" element={<Documents />} />
                     {/* Ruta fallback: todo lo desconocido a dashboard */}
                     <Route path="*" element={<Navigate to="/dashboard" replace />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -14,6 +14,7 @@ import MyWindowPortal from "./MyWindowPortal";
 
 export default function Sidebar() {
   const [openSections, setOpenSections] = useState({});
+  const [openSubmenus, setOpenSubmenus] = useState({});
   const [popup, setPopup] = useState(null);
 
   useEffect(() => {
@@ -25,14 +26,26 @@ export default function Sidebar() {
         localStorage.removeItem("openSections");
       }
     }
+    const storedSubs = localStorage.getItem("openSubmenus");
+    if (storedSubs) {
+      try {
+        setOpenSubmenus(JSON.parse(storedSubs));
+      } catch {
+        localStorage.removeItem("openSubmenus");
+      }
+    }
   }, []);
 
   useEffect(() => {
     localStorage.setItem("openSections", JSON.stringify(openSections));
-  }, [openSections]);
+    localStorage.setItem("openSubmenus", JSON.stringify(openSubmenus));
+  }, [openSections, openSubmenus]);
 
   const toggleSection = (title) =>
     setOpenSections((prev) => ({ ...prev, [title]: !prev[title] }));
+
+  const toggleSubmenu = (key) =>
+    setOpenSubmenus((prev) => ({ ...prev, [key]: !prev[key] }));
 
   const openPopup = (Component, title, width = 1000, height = 700) => {
     const tempOrderId = `temp-${Date.now()}-${Math.floor(
@@ -51,21 +64,31 @@ export default function Sidebar() {
       items: [
         { label: "Clientes", to: "/clients" },
         { label: "Proveedores", to: "/suppliers" },
-        { label: "Marcas", to: "/brands" },
-        { label: "Condiciones", to: "/saleconditions" },
-        { label: "Grupos Tarjetas", to: "/creditcardgroups" },
-        { label: "Tarjetas", to: "/creditcards" },
-        { label: "Categorías", to: "/itemcategories" },
-        { label: "Subcategorías", to: "/itemsubcategories" },
-        { label: "Ítems", to: "/items" },
-      ],
-    },
-    {
-      title: "Autos",
-      items: [
-        { label: "Marcas de autos", to: "/carbrands" },
-        { label: "Modelos de autos", to: "/carmodels" },
-        { label: "Autos", to: "/cars" },
+        {
+          label: "Productos",
+          submenu: [
+            { label: "Categorías", to: "/itemcategories" },
+            { label: "Subcategorías", to: "/itemsubcategories" },
+            { label: "Marcas", to: "/brands" },
+            { label: "Ítems", to: "/items" },
+          ],
+        },
+        {
+          label: "Ventas",
+          submenu: [
+            { label: "Grupos Tarjetas", to: "/creditcardgroups" },
+            { label: "Tarjetas", to: "/creditcards" },
+            { label: "Condiciones", to: "/saleconditions" },
+          ],
+        },
+        {
+          label: "Autos",
+          submenu: [
+            { label: "Marcas de autos", to: "/carbrands" },
+            { label: "Modelos de autos", to: "/carmodels" },
+            { label: "Autos", to: "/cars" },
+          ],
+        },
       ],
     },
     {
@@ -128,33 +151,78 @@ export default function Sidebar() {
 
                 {isOpen && (
                   <ul className="mt-1 ml-4 space-y-1">
-                    {section.items.map((item) => (
-                      <li key={item.label}>
-                        {item.to ? (
-                          <NavLink
-                            to={item.to}
-                            className={({ isActive }) =>
-                              `flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-100 ${
-                                isActive
-                                  ? "bg-gray-200 font-medium"
-                                  : "text-gray-700"
-                              }`
-                            }
-                          >
-                            <FileText size={16} />
-                            {item.label}
-                          </NavLink>
-                        ) : (
-                          <button
-                            onClick={item.action}
-                            className="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-100 text-gray-700 w-full text-left"
-                          >
-                            <FileText size={16} />
-                            {item.label}
-                          </button>
-                        )}
-                      </li>
-                    ))}
+                    {section.items.map((item) => {
+                      const key = `${section.title}-${item.label}`;
+                      if (item.submenu) {
+                        const subOpen = openSubmenus[key];
+                        return (
+                          <li key={item.label}>
+                            <button
+                              onClick={() => toggleSubmenu(key)}
+                              className="flex items-center justify-between w-full px-2 py-1 rounded hover:bg-gray-100 text-gray-700"
+                            >
+                              <span className="flex items-center gap-2">
+                                <FileText size={16} />{item.label}
+                              </span>
+                              {subOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+                            </button>
+                            {subOpen && (
+                              <ul className="mt-1 ml-4 space-y-1">
+                                {item.submenu.map((sub) => (
+                                  <li key={sub.label}>
+                                    {sub.to ? (
+                                      <NavLink
+                                        to={sub.to}
+                                        className={({ isActive }) =>
+                                          `flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-100 ${
+                                            isActive ? "bg-gray-200 font-medium" : "text-gray-700"`
+                                        }
+                                      >
+                                        <FileText size={16} />
+                                        {sub.label}
+                                      </NavLink>
+                                    ) : (
+                                      <button
+                                        onClick={sub.action}
+                                        className="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-100 text-gray-700 w-full text-left"
+                                      >
+                                        <FileText size={16} />
+                                        {sub.label}
+                                      </button>
+                                    )}
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                          </li>
+                        );
+                      }
+                      return (
+                        <li key={item.label}>
+                          {item.to ? (
+                            <NavLink
+                              to={item.to}
+                              className={({ isActive }) =>
+                                `flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-100 ${
+                                  isActive ? "bg-gray-200 font-medium" : "text-gray-700"
+                                }`
+                              }
+                            >
+                              <FileText size={16} />
+                              {item.label}
+                            </NavLink>
+                          ) : (
+                            <button
+                              onClick={item.action}
+                              className="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-100 text-gray-700 w-full text-left"
+                            >
+                              <FileText size={16} />
+                              {item.label}
+                            </button>
+                          )}
+                        </li>
+                      );
+                    })}
                   </ul>
                 )}
               </div>

--- a/frontend/src/pages/CarCreate.jsx
+++ b/frontend/src/pages/CarCreate.jsx
@@ -1,0 +1,143 @@
+import { useState, useEffect } from "react";
+import { carOperations, carModelOperations, clientOperations, discountOperations } from "../utils/graphqlClient";
+
+export default function CarCreate({ onClose, onSave, car: initialCar = null }) {
+    const [form, setForm] = useState({
+        licensePlate: "",
+        year: "",
+        carModelID: "",
+        clientID: "",
+        lastServiceMileage: "",
+        isDebtor: false,
+        discountID: "",
+    });
+
+    const [models, setModels] = useState([]);
+    const [clients, setClients] = useState([]);
+    const [discounts, setDiscounts] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [isEdit, setIsEdit] = useState(false);
+
+    useEffect(() => {
+        const loadData = async () => {
+            try {
+                const [m, c, d] = await Promise.all([
+                    carModelOperations.getAllCarModels(),
+                    clientOperations.getAllClients(),
+                    discountOperations.getAllDiscounts(),
+                ]);
+                setModels(m);
+                setClients(c);
+                setDiscounts(d);
+            } catch (err) {
+                console.error("Error cargando datos:", err);
+            }
+        };
+        loadData();
+    }, []);
+
+    useEffect(() => {
+        if (initialCar) {
+            setIsEdit(true);
+            setForm({
+                licensePlate: initialCar.LicensePlate || "",
+                year: initialCar.Year || "",
+                carModelID: initialCar.CarModelID || "",
+                clientID: initialCar.ClientID || "",
+                lastServiceMileage: initialCar.LastServiceMileage || "",
+                isDebtor: initialCar.IsDebtor || false,
+                discountID: initialCar.DiscountID || "",
+            });
+        }
+    }, [initialCar]);
+
+    const handleChange = (e) => {
+        const { name, type, value, checked } = e.target;
+        setForm(prev => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            const payload = {
+                LicensePlate: form.licensePlate,
+                Year: form.year ? parseInt(form.year) : null,
+                CarModelID: parseInt(form.carModelID),
+                ClientID: parseInt(form.clientID),
+                LastServiceMileage: form.lastServiceMileage ? parseInt(form.lastServiceMileage) : null,
+                IsDebtor: form.isDebtor,
+                DiscountID: parseInt(form.discountID),
+            };
+            let result;
+            if (isEdit) {
+                result = await carOperations.updateCar(initialCar.CarID, payload);
+            } else {
+                result = await carOperations.createCar(payload);
+            }
+            onSave && onSave(result);
+            onClose && onClose();
+        } catch (err) {
+            console.error("Error guardando auto:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Auto' : 'Nuevo Auto'}</h2>
+            {error && <div className="text-red-600 mb-2">{error}</div>}
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-1">Modelo</label>
+                    <select name="carModelID" value={form.carModelID} onChange={handleChange} className="w-full border p-2 rounded" required>
+                        <option value="">Seleccione</option>
+                        {models.map(m => <option key={m.CarModelID} value={m.CarModelID}>{m.Model}</option>)}
+                    </select>
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Cliente</label>
+                    <select name="clientID" value={form.clientID} onChange={handleChange} className="w-full border p-2 rounded" required>
+                        <option value="">Seleccione</option>
+                        {clients.map(c => <option key={c.ClientID} value={c.ClientID}>{c.FirstName} {c.LastName}</option>)}
+                    </select>
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Patente</label>
+                    <input type="text" name="licensePlate" value={form.licensePlate} onChange={handleChange} className="w-full border p-2 rounded" required />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Año</label>
+                    <input type="number" name="year" value={form.year} onChange={handleChange} className="w-full border p-2 rounded" />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Kilometraje último servicio</label>
+                    <input type="number" name="lastServiceMileage" value={form.lastServiceMileage} onChange={handleChange} className="w-full border p-2 rounded" />
+                </div>
+                <div>
+                    <label className="inline-flex items-center">
+                        <input type="checkbox" name="isDebtor" checked={form.isDebtor} onChange={handleChange} className="mr-2" />
+                        <span>Deudor</span>
+                    </label>
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Descuento</label>
+                    <select name="discountID" value={form.discountID} onChange={handleChange} className="w-full border p-2 rounded" required>
+                        <option value="">Seleccione</option>
+                        {discounts.map(d => <option key={d.DiscountID} value={d.DiscountID}>{d.DiscountName}</option>)}
+                    </select>
+                </div>
+                <div className="flex justify-end space-x-4 pt-4 border-t">
+                    <button type="button" onClick={onClose} disabled={loading} className="px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50">Cancelar</button>
+                    <button type="submit" disabled={loading || !form.licensePlate || !form.carModelID || !form.clientID || !form.discountID} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+                        {loading ? 'Guardando...' : 'Guardar'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/pages/CarModelCreate.jsx
+++ b/frontend/src/pages/CarModelCreate.jsx
@@ -1,0 +1,79 @@
+import { useState, useEffect } from "react";
+import { carModelOperations, carBrandOperations } from "../utils/graphqlClient";
+
+export default function CarModelCreate({ onClose, onSave, carModel: initialCarModel = null }) {
+    const [carBrandID, setCarBrandID] = useState("");
+    const [model, setModel] = useState("");
+    const [brands, setBrands] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [isEdit, setIsEdit] = useState(false);
+
+    useEffect(() => {
+        const loadBrands = async () => {
+            try {
+                const b = await carBrandOperations.getAllCarBrands();
+                setBrands(b);
+            } catch (err) {
+                console.error("Error cargando marcas de auto:", err);
+            }
+        };
+        loadBrands();
+    }, []);
+
+    useEffect(() => {
+        if (initialCarModel) {
+            setIsEdit(true);
+            setCarBrandID(initialCarModel.CarBrandID || "");
+            setModel(initialCarModel.Model || "");
+        }
+    }, [initialCarModel]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            let result;
+            const payload = { CarBrandID: parseInt(carBrandID), Model: model };
+            if (isEdit) {
+                result = await carModelOperations.updateCarModel(initialCarModel.CarModelID, payload);
+            } else {
+                result = await carModelOperations.createCarModel(payload);
+            }
+            onSave && onSave(result);
+            onClose && onClose();
+        } catch (err) {
+            console.error("Error guardando modelo de auto:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Modelo de Auto' : 'Nuevo Modelo de Auto'}</h2>
+            {error && <div className="text-red-600 mb-2">{error}</div>}
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-1">Marca de auto</label>
+                    <select value={carBrandID} onChange={(e) => setCarBrandID(e.target.value)} className="w-full border p-2 rounded" required>
+                        <option value="">Seleccione</option>
+                        {brands.map(b => <option key={b.CarBrandID} value={b.CarBrandID}>{b.Name}</option>)}
+                    </select>
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Modelo</label>
+                    <input type="text" value={model} onChange={(e) => setModel(e.target.value)} className="w-full border p-2 rounded" required />
+                </div>
+                <div className="flex justify-end space-x-4 pt-4 border-t">
+                    <button type="button" onClick={onClose} disabled={loading} className="px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50">Cancelar</button>
+                    <button type="submit" disabled={loading || !carBrandID || !model.trim()} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+                        {loading ? 'Guardando...' : 'Guardar'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/pages/CarModels.jsx
+++ b/frontend/src/pages/CarModels.jsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { carModelOperations } from "../utils/graphqlClient";
+import CarModelCreate from "./CarModelCreate";
+import TableFilters from "../components/TableFilters";
+
+export default function CarModels() {
+    const [allModels, setAllModels] = useState([]);
+    const [models, setModels] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [showModal, setShowModal] = useState(false);
+    const [editing, setEditing] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
+
+    useEffect(() => { loadModels(); }, []);
+
+    const loadModels = async () => {
+        try {
+            setLoading(true);
+            const data = await carModelOperations.getAllCarModels();
+            setAllModels(data);
+            setModels(data);
+        } catch (err) {
+            console.error("Error cargando modelos de auto:", err);
+            setError(err.message);
+            setModels([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleSaved = () => {
+        loadModels();
+        setShowModal(false);
+        setEditing(null);
+    };
+
+    const handleCreate = () => {
+        setEditing(null);
+        setShowModal(true);
+    };
+
+    const handleFilterChange = (filtered) => setModels(filtered);
+
+    const handleEdit = (m) => {
+        setEditing(m);
+        setShowModal(true);
+    };
+
+    return (
+        <div className="p-6">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold text-gray-800">Modelos de Auto</h1>
+                <div className="flex space-x-2">
+                    <button onClick={() => setShowFilters(!showFilters)} className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700">
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button onClick={loadModels} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Recargar</button>
+                    <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">Nuevo Modelo</button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters modelName="carmodels" data={allModels} onFilterChange={handleFilterChange} />
+                </div>
+            )}
+            {error && <div className="text-red-600 mb-4">{error}</div>}
+            {loading ? (
+                <div>Cargando...</div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {models.map(m => (
+                        <div key={m.CarModelID} className="bg-white rounded shadow p-4">
+                            <h3 className="text-lg font-semibold mb-2">{m.Model}</h3>
+                            <p className="text-sm mb-2">Marca ID: {m.CarBrandID}</p>
+                            <button onClick={() => handleEdit(m)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                        </div>
+                    ))}
+                </div>
+            )}
+            {showModal && (
+                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+                    <div className="bg-white rounded-lg max-w-md w-full">
+                        <CarModelCreate onClose={() => { setShowModal(false); setEditing(null); }} onSave={handleSaved} carModel={editing} />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/pages/Cars.jsx
+++ b/frontend/src/pages/Cars.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { carOperations } from "../utils/graphqlClient";
+import CarCreate from "./CarCreate";
+import TableFilters from "../components/TableFilters";
+
+export default function Cars() {
+    const [allCars, setAllCars] = useState([]);
+    const [cars, setCars] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [showModal, setShowModal] = useState(false);
+    const [editing, setEditing] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
+
+    useEffect(() => { loadCars(); }, []);
+
+    const loadCars = async () => {
+        try {
+            setLoading(true);
+            const data = await carOperations.getAllCars();
+            setAllCars(data);
+            setCars(data);
+        } catch (err) {
+            console.error("Error cargando autos:", err);
+            setError(err.message);
+            setCars([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleSaved = () => {
+        loadCars();
+        setShowModal(false);
+        setEditing(null);
+    };
+
+    const handleCreate = () => {
+        setEditing(null);
+        setShowModal(true);
+    };
+
+    const handleFilterChange = (filtered) => setCars(filtered);
+
+    const handleEdit = (c) => {
+        setEditing(c);
+        setShowModal(true);
+    };
+
+    return (
+        <div className="p-6">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold text-gray-800">Autos</h1>
+                <div className="flex space-x-2">
+                    <button onClick={() => setShowFilters(!showFilters)} className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700">
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button onClick={loadCars} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Recargar</button>
+                    <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">Nuevo Auto</button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters modelName="cars" data={allCars} onFilterChange={handleFilterChange} />
+                </div>
+            )}
+            {error && <div className="text-red-600 mb-4">{error}</div>}
+            {loading ? (
+                <div>Cargando...</div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {cars.map(c => (
+                        <div key={c.CarID} className="bg-white rounded shadow p-4">
+                            <h3 className="text-lg font-semibold mb-2">{c.LicensePlate}</h3>
+                            <p className="text-sm mb-1">Año: {c.Year || '—'}</p>
+                            <p className="text-sm mb-1">Modelo ID: {c.CarModelID}</p>
+                            <button onClick={() => handleEdit(c)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                        </div>
+                    ))}
+                </div>
+            )}
+            {showModal && (
+                <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+                    <div className="bg-white rounded-lg max-w-md w-full">
+                        <CarCreate onClose={() => { setShowModal(false); setEditing(null); }} onSave={handleSaved} car={editing} />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/utils/graphqlClient.js
+++ b/frontend/src/utils/graphqlClient.js
@@ -428,6 +428,67 @@ export const QUERIES = {
         }
     `,
 
+    // MODELOS DE AUTO
+    GET_ALL_CARMODELS: `
+        query GetAllCarModels {
+            allCarmodels {
+                CarModelID
+                CarBrandID
+                Model
+            }
+        }
+    `,
+    GET_CARMODEL_BY_ID: `
+        query GetCarModelById($id: Int!) {
+            carmodelsById(id: $id) {
+                CarModelID
+                CarBrandID
+                Model
+            }
+        }
+    `,
+
+    // AUTOS
+    GET_ALL_CARS: `
+        query GetAllCars {
+            allCars {
+                CarID
+                LicensePlate
+                Year
+                CarModelID
+                ClientID
+                LastServiceMileage
+                IsDebtor
+                DiscountID
+            }
+        }
+    `,
+    GET_CAR_BY_ID: `
+        query GetCarById($id: Int!) {
+            carsById(id: $id) {
+                CarID
+                LicensePlate
+                Year
+                CarModelID
+                ClientID
+                LastServiceMileage
+                IsDebtor
+                DiscountID
+            }
+        }
+    `,
+
+    // DESCUENTOS
+    GET_ALL_DISCOUNTS: `
+        query GetAllDiscounts {
+            allDiscounts {
+                DiscountID
+                DiscountName
+                Percentage
+            }
+        }
+    `,
+
     // GRUPOS DE TARJETAS DE CRÉDITO
     GET_ALL_CREDITCARDGROUPS: `
         query GetAllCreditCardGroups {
@@ -761,6 +822,66 @@ export const MUTATIONS = {
     DELETE_CARBRAND: `
         mutation DeleteCarBrand($carBrandID: Int!) {
             deleteCarbrand(carBrandID: $carBrandID)
+        }
+    `,
+
+    // MODELOS DE AUTO
+    CREATE_CARMODEL: `
+        mutation CreateCarModel($input: CarModelsCreate!) {
+            createCarmodel(data: $input) {
+                CarModelID
+                CarBrandID
+                Model
+            }
+        }
+    `,
+    UPDATE_CARMODEL: `
+        mutation UpdateCarModel($carModelID: Int!, $input: CarModelsUpdate!) {
+            updateCarmodel(carModelID: $carModelID, data: $input) {
+                CarModelID
+                CarBrandID
+                Model
+            }
+        }
+    `,
+    DELETE_CARMODEL: `
+        mutation DeleteCarModel($carModelID: Int!) {
+            deleteCarmodel(carModelID: $carModelID)
+        }
+    `,
+
+    // AUTOS
+    CREATE_CAR: `
+        mutation CreateCar($input: CarsCreate!) {
+            createCar(data: $input) {
+                CarID
+                LicensePlate
+                Year
+                CarModelID
+                ClientID
+                LastServiceMileage
+                IsDebtor
+                DiscountID
+            }
+        }
+    `,
+    UPDATE_CAR: `
+        mutation UpdateCar($carID: Int!, $input: CarsUpdate!) {
+            updateCar(carID: $carID, data: $input) {
+                CarID
+                LicensePlate
+                Year
+                CarModelID
+                ClientID
+                LastServiceMileage
+                IsDebtor
+                DiscountID
+            }
+        }
+    `,
+    DELETE_CAR: `
+        mutation DeleteCar($carID: Int!) {
+            deleteCar(carID: $carID)
         }
     `,
 
@@ -1354,6 +1475,132 @@ export const carBrandOperations = {
             return data.deleteCarbrand;
         } catch (error) {
             console.error("Error eliminando marca de auto:", error);
+            throw error;
+        }
+    }
+};
+
+export const carModelOperations = {
+    async getAllCarModels() {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_ALL_CARMODELS);
+            return data.allCarmodels || [];
+        } catch (error) {
+            console.error("Error obteniendo modelos de auto:", error);
+            throw error;
+        }
+    },
+
+    async getCarModelById(id) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_CARMODEL_BY_ID, { id });
+            return data.carmodelsById;
+        } catch (error) {
+            console.error("Error obteniendo modelo de auto:", error);
+            throw error;
+        }
+    },
+
+    async createCarModel(carmodelData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.CREATE_CARMODEL, {
+                input: carmodelData
+            });
+            return data.createCarmodel;
+        } catch (error) {
+            console.error("Error creando modelo de auto:", error);
+            throw error;
+        }
+    },
+
+    async updateCarModel(id, carmodelData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_CARMODEL, {
+                carModelID: id,
+                input: carmodelData
+            });
+            return data.updateCarmodel;
+        } catch (error) {
+            console.error("Error actualizando modelo de auto:", error);
+            throw error;
+        }
+    },
+
+    async deleteCarModel(id) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.DELETE_CARMODEL, {
+                carModelID: id
+            });
+            return data.deleteCarmodel;
+        } catch (error) {
+            console.error("Error eliminando modelo de auto:", error);
+            throw error;
+        }
+    }
+};
+
+export const carOperations = {
+    async getAllCars() {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_ALL_CARS);
+            return data.allCars || [];
+        } catch (error) {
+            console.error("Error obteniendo autos:", error);
+            throw error;
+        }
+    },
+
+    async getCarById(id) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_CAR_BY_ID, { id });
+            return data.carsById;
+        } catch (error) {
+            console.error("Error obteniendo auto:", error);
+            throw error;
+        }
+    },
+
+    async createCar(carData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.CREATE_CAR, { input: carData });
+            return data.createCar;
+        } catch (error) {
+            console.error("Error creando auto:", error);
+            throw error;
+        }
+    },
+
+    async updateCar(id, carData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_CAR, {
+                carID: id,
+                input: carData
+            });
+            return data.updateCar;
+        } catch (error) {
+            console.error("Error actualizando auto:", error);
+            throw error;
+        }
+    },
+
+    async deleteCar(id) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.DELETE_CAR, { carID: id });
+            return data.deleteCar;
+        } catch (error) {
+            console.error("Error eliminando auto:", error);
+            throw error;
+        }
+    }
+};
+
+export const discountOperations = {
+    async getAllDiscounts() {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_ALL_DISCOUNTS);
+            return data.allDiscounts || [];
+        } catch (error) {
+            console.error("Error obteniendo descuentos:", error);
             throw error;
         }
     }


### PR DESCRIPTION
## Summary
- add GraphQL mutations for car models and cars
- expose new mutations in schema
- add frontend CRUD operations for car models and cars
- implement pages for car models and cars
- nest product, sales and autos menus under Archivo in Sidebar
- update routes to handle car models and cars

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run lint` *(fails: eslint errors)*
- `npm --prefix frontend run test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68694d7bd3688323876df4f61ca8e95c