### PR TITLE
Fix Sidebar template string bug

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -175,9 +175,9 @@ export default function Sidebar() {
                                         to={sub.to}
                                         className={({ isActive }) =>
                                           `flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-100 ${
-                                            isActive ? "bg-gray-200 font-medium" : "text-gray-700"`
-                                        }
-                                      >
+                                            isActive ? "bg-gray-200 font-medium" : "text-gray-700"
+                                          }`
+                                        >
                                         <FileText size={16} />
                                         {sub.label}
                                       </NavLink>
@@ -222,12 +222,12 @@ export default function Sidebar() {
                           )}
                         </li>
                       );
-                    })}
+                    })
                   </ul>
                 )}
               </div>
             );
-          })}
+          })
         </nav>
       </aside>
       {popup}


### PR DESCRIPTION
## Summary
- fix incorrectly closed template literals in `Sidebar.jsx`
- remove extraneous closing braces after `map` loops

## Testing
- `npm test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_686952bdb35c83238b85baf563cc6787