### PR TITLE
Fix Sidebar JSX syntax

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -177,6 +177,7 @@ export default function Sidebar() {
                                           `flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-100 ${
                                             isActive ? "bg-gray-200 font-medium" : "text-gray-700"
                                           }`
+                                        }
                                         >
                                         <FileText size={16} />
                                         {sub.label}


### PR DESCRIPTION
## Summary
- fix missing closing brace for `className` in Sidebar

## Testing
- `npm run lint` *(fails: 'module' is not defined in tailwind.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6869629a43008323bcedae5e71f3cfd0