### PR TITLE
Add client search modal

### DIFF
--- a/frontend/src/components/ClientSearchModal.jsx
+++ b/frontend/src/components/ClientSearchModal.jsx
@@ -1,0 +1,139 @@
+import React, { useState, useEffect } from "react";
+import apiFetch from "../utils/apiFetch";
+
+export default function ClientSearchModal({ isOpen, onClose, onClientSelect }) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setQuery("");
+      setResults([]);
+    }
+  }, [isOpen]);
+
+  const handleSearch = async () => {
+    if (!query.trim()) return;
+    setIsLoading(true);
+    try {
+      const data = await apiFetch(
+        `/clients/search/?name=${encodeURIComponent(query)}`
+      );
+      setResults(data || []);
+    } catch (err) {
+      console.error("Error searching clients:", err);
+      setResults([]);
+    }
+    setIsLoading(false);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 flex justify-center items-start pt-10">
+      <div className="relative mx-auto p-5 border w-full max-w-xl shadow-lg rounded-md bg-white space-y-4">
+        <div className="flex justify-between items-center pb-3 border-b">
+          <h3 className="text-xl font-semibold text-gray-700">Buscar Clientes</h3>
+          <button
+            onClick={onClose}
+            className="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className="flex space-x-2">
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+            className="flex-1 border rounded px-3 py-2"
+            placeholder="Nombre o documento..."
+          />
+          <button
+            onClick={handleSearch}
+            className="px-3 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+          >
+            Buscar
+          </button>
+        </div>
+        <div className="max-h-96 overflow-y-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50 sticky top-0">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  ID
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Nombre
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Documento
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Acción
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {results.length > 0 ? (
+                results.map((c) => (
+                  <tr key={c.clientID} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
+                      {c.clientID}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
+                      {c.firstName} {c.lastName || ""}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
+                      {c.docNumber || ""}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap text-sm font-medium">
+                      <button
+                        onClick={() => {
+                          onClientSelect(c);
+                          onClose();
+                        }}
+                        className="text-indigo-600 hover:text-indigo-900"
+                      >
+                        Seleccionar
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan="4" className="px-4 py-10 text-center text-sm text-gray-500">
+                    {isLoading ? "Buscando..." : "No se encontraron clientes"}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+        <div className="pt-3 border-t flex justify-end">
+          <button
+            onClick={onClose}
+            className="bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-2 px-4 rounded-md shadow-sm text-sm"
+          >
+            Cerrar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/OrderCreate.jsx
+++ b/frontend/src/pages/OrderCreate.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from "react";
 import apiFetch from "../utils/apiFetch";
 import ItemSearchModal from "../components/ItemSearchModal"; // Importar el modal
+import ClientSearchModal from "../components/ClientSearchModal";
 import MyWindowPortal from "../components/MyWindowPortal"; // Importar el portal
 
 export default function OrderCreate({ userInfo }) {
@@ -44,6 +45,7 @@ export default function OrderCreate({ userInfo }) {
   });
   const [showClientDropdown, setShowClientDropdown] = useState(false);
   const [showItemSearchModal, setShowItemSearchModal] = useState(false); // Estado para el modal de búsqueda de ítems
+  const [showClientSearchModal, setShowClientSearchModal] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -277,11 +279,11 @@ export default function OrderCreate({ userInfo }) {
                 >
                   Buscar Cliente por Nombre
                 </label>
-                <input
-                  type="text"
-                  id="clientSearch"
-                  value={clientSearch}
-                  onChange={handleClientSearchChange}
+              <input
+                type="text"
+                id="clientSearch"
+                value={clientSearch}
+                onChange={handleClientSearchChange}
                   onBlur={() => {
                     setTimeout(() => {
                       const activeElement = document.activeElement;
@@ -301,9 +303,29 @@ export default function OrderCreate({ userInfo }) {
                   }}
                   placeholder="Escriba para buscar..."
                   className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 py-2 px-3"
-                  autoComplete="off"
-                />
-                {showClientDropdown && (
+                autoComplete="off"
+              />
+              <button
+                type="button"
+                onClick={() => setShowClientSearchModal(true)}
+                className="absolute right-2 top-9 text-gray-500 hover:text-gray-700"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                  />
+                </svg>
+              </button>
+              {showClientDropdown && (
                   <ul
                     id="client-dropdown-list"
                     className="absolute z-30 mt-1 w-full bg-white shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm"
@@ -763,6 +785,20 @@ export default function OrderCreate({ userInfo }) {
             // Así que el onClose que ya tiene debería funcionar para cerrar el portal.
           />
         </MyWindowPortal>
+      )}
+      {showClientSearchModal && (
+        <ClientSearchModal
+          isOpen={true}
+          onClose={() => setShowClientSearchModal(false)}
+          onClientSelect={(c) => {
+            handleClientSelection({
+              clientID: c.clientID,
+              firstName: c.firstName,
+              lastName: c.lastName,
+            });
+            setShowClientSearchModal(false);
+          }}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add a modal to search and pick clients
- hook up the modal in the Order Create page with a button

## Testing
- `npm run lint` *(fails: many unused variables across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68697b64d3748323a507e99ac9a2bfeb