### PR TITLE
Add advanced filters in search modals

### DIFF
--- a/frontend/src/components/CarBrandSearchModal.jsx
+++ b/frontend/src/components/CarBrandSearchModal.jsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { carBrandOperations } from "../utils/graphqlClient";
+import TableFilters from "./TableFilters";
 
 export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) {
   const [brands, setBrands] = useState([]);
+  const [filteredBrands, setFilteredBrands] = useState([]);
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -12,10 +15,14 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
       setIsLoading(true);
       carBrandOperations
         .getAllCarBrands()
-        .then((data) => setBrands(data || []))
+        .then((data) => {
+          setBrands(data || []);
+          setFilteredBrands(data || []);
+        })
         .catch((err) => {
           console.error("Error fetching brands:", err);
           setBrands([]);
+          setFilteredBrands([]);
         })
         .finally(() => setIsLoading(false));
     }
@@ -23,7 +30,7 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
 
   if (!isOpen) return null;
 
-  const filtered = brands.filter((b) =>
+  const filtered = filteredBrands.filter((b) =>
     b.Name.toLowerCase().includes(query.toLowerCase())
   );
 
@@ -41,7 +48,7 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
             </svg>
           </button>
         </div>
-        <div className="flex space-x-2">
+        <div className="flex space-x-2 items-center">
           <input
             type="text"
             value={query}
@@ -49,7 +56,21 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
             className="flex-1 border rounded px-3 py-2"
             placeholder="Nombre de marca..."
           />
+          <button
+            type="button"
+            onClick={() => setShowFilters(!showFilters)}
+            className="px-3 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 text-sm"
+          >
+            {showFilters ? "Ocultar Filtros" : "Mostrar Filtros"}
+          </button>
         </div>
+        {showFilters && (
+          <TableFilters
+            modelName="carbrands"
+            data={brands}
+            onFilterChange={setFilteredBrands}
+          />
+        )}
         <div className="max-h-80 overflow-y-auto">
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50 sticky top-0">

--- a/frontend/src/components/ClientSearchModal.jsx
+++ b/frontend/src/components/ClientSearchModal.jsx
@@ -1,32 +1,39 @@
 import React, { useState, useEffect } from "react";
-import apiFetch from "../utils/apiFetch";
+import { graphqlClient, QUERIES } from "../utils/graphqlClient";
+import TableFilters from "./TableFilters";
 
 export default function ClientSearchModal({ isOpen, onClose, onClientSelect }) {
+  const [clients, setClients] = useState([]);
+  const [filteredClients, setFilteredClients] = useState([]);
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
 
   useEffect(() => {
+    async function loadClients() {
+      setIsLoading(true);
+      try {
+        const data = await graphqlClient.query(QUERIES.GET_ALL_CLIENTS);
+        const list = data?.allClients || [];
+        setClients(list);
+        setFilteredClients(list);
+      } catch (err) {
+        console.error("Error fetching clients:", err);
+        setClients([]);
+        setFilteredClients([]);
+      }
+      setIsLoading(false);
+    }
     if (isOpen) {
       setQuery("");
-      setResults([]);
+      loadClients();
     }
   }, [isOpen]);
 
-  const handleSearch = async () => {
-    if (!query.trim()) return;
-    setIsLoading(true);
-    try {
-      const data = await apiFetch(
-        `/clients/search/?name=${encodeURIComponent(query)}`
-      );
-      setResults(data || []);
-    } catch (err) {
-      console.error("Error searching clients:", err);
-      setResults([]);
-    }
-    setIsLoading(false);
-  };
+  const filtered = filteredClients.filter((c) => {
+    const fullName = `${c.FirstName} ${c.LastName || ""}`.toLowerCase();
+    return fullName.includes(query.toLowerCase());
+  });
 
   if (!isOpen) return null;
 
@@ -60,17 +67,24 @@ export default function ClientSearchModal({ isOpen, onClose, onClientSelect }) {
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && handleSearch()}
             className="flex-1 border rounded px-3 py-2"
             placeholder="Nombre o documento..."
           />
           <button
-            onClick={handleSearch}
-            className="px-3 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+            type="button"
+            onClick={() => setShowFilters(!showFilters)}
+            className="px-3 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 text-sm"
           >
-            Buscar
+            {showFilters ? "Ocultar Filtros" : "Mostrar Filtros"}
           </button>
         </div>
+        {showFilters && (
+          <TableFilters
+            modelName="clients"
+            data={clients}
+            onFilterChange={setFilteredClients}
+          />
+        )}
         <div className="max-h-96 overflow-y-auto">
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50 sticky top-0">
@@ -90,8 +104,8 @@ export default function ClientSearchModal({ isOpen, onClose, onClientSelect }) {
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
-              {results.length > 0 ? (
-                results.map((c) => (
+              {filtered.length > 0 ? (
+                filtered.map((c) => (
                   <tr key={c.clientID} className="hover:bg-gray-50">
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
                       {c.clientID}

--- a/frontend/src/pages/CarCreate.jsx
+++ b/frontend/src/pages/CarCreate.jsx
@@ -115,41 +115,47 @@ export default function CarCreate({ onClose, onSave, car: initialCar = null }) {
             <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Auto' : 'Nuevo Auto'}</h2>
             {error && <div className="text-red-600 mb-2">{error}</div>}
             <form onSubmit={handleSubmit} className="space-y-4">
-                <div className="relative">
+                <div>
                     <label className="block text-sm font-medium mb-1">Marca</label>
-                    <select name="carBrandID" value={form.carBrandID} onChange={handleChange} className="w-full border p-2 rounded" required>
-                        <option value="">Seleccione</option>
-                        {brands.map(b => <option key={b.CarBrandID} value={b.CarBrandID}>{b.Name}</option>)}
-                    </select>
-                    <button type="button" onClick={() => setShowBrandModal(true)} className="absolute right-2 top-8 text-gray-500 hover:text-gray-700">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                        </svg>
-                    </button>
+                    <div className="flex items-center space-x-2">
+                        <select name="carBrandID" value={form.carBrandID} onChange={handleChange} className="flex-1 border p-2 rounded" required>
+                            <option value="">Seleccione</option>
+                            {brands.map(b => <option key={b.CarBrandID} value={b.CarBrandID}>{b.Name}</option>)}
+                        </select>
+                        <button type="button" onClick={() => setShowBrandModal(true)} className="text-gray-500 hover:text-gray-700">
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                        </button>
+                    </div>
                 </div>
-                <div className="relative">
+                <div>
                     <label className="block text-sm font-medium mb-1">Modelo</label>
-                    <select name="carModelID" value={form.carModelID} onChange={handleChange} className="w-full border p-2 rounded" required disabled={!form.carBrandID}>
-                        <option value="">Seleccione</option>
-                        {models.map(m => <option key={m.CarModelID} value={m.CarModelID}>{m.Model}</option>)}
-                    </select>
-                    <button type="button" onClick={() => setShowModelModal(true)} className="absolute right-2 top-8 text-gray-500 hover:text-gray-700">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                        </svg>
-                    </button>
+                    <div className="flex items-center space-x-2">
+                        <select name="carModelID" value={form.carModelID} onChange={handleChange} className="flex-1 border p-2 rounded" required disabled={!form.carBrandID}>
+                            <option value="">Seleccione</option>
+                            {models.map(m => <option key={m.CarModelID} value={m.CarModelID}>{m.Model}</option>)}
+                        </select>
+                        <button type="button" onClick={() => setShowModelModal(true)} className="text-gray-500 hover:text-gray-700">
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                        </button>
+                    </div>
                 </div>
-                <div className="relative">
+                <div>
                     <label className="block text-sm font-medium mb-1">Cliente</label>
-                    <select name="clientID" value={form.clientID} onChange={handleChange} className="w-full border p-2 rounded" required>
-                        <option value="">Seleccione</option>
-                        {clients.map(c => <option key={c.ClientID} value={c.ClientID}>{c.FirstName} {c.LastName}</option>)}
-                    </select>
-                    <button type="button" onClick={() => setShowClientModal(true)} className="absolute right-2 top-8 text-gray-500 hover:text-gray-700">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                        </svg>
-                    </button>
+                    <div className="flex items-center space-x-2">
+                        <select name="clientID" value={form.clientID} onChange={handleChange} className="flex-1 border p-2 rounded" required>
+                            <option value="">Seleccione</option>
+                            {clients.map(c => <option key={c.ClientID} value={c.ClientID}>{c.FirstName} {c.LastName}</option>)}
+                        </select>
+                        <button type="button" onClick={() => setShowClientModal(true)} className="text-gray-500 hover:text-gray-700">
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                        </button>
+                    </div>
                 </div>
                 <div>
                     <label className="block text-sm font-medium mb-1">Patente</label>


### PR DESCRIPTION
## Summary
- reuse `TableFilters` in client/car brand/car model search modals
- tweak `CarCreate` select layout so magnifier buttons sit outside dropdowns

## Testing
- `npm run lint` *(fails: many unused vars across repo)*

------
https://chatgpt.com/codex/tasks/task_e_6869820e5cc88323984990feee88d58f