### PR TITLE
Add overlay filters and fix select labels

### DIFF
--- a/frontend/src/components/CarBrandSearchModal.jsx
+++ b/frontend/src/components/CarBrandSearchModal.jsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { carBrandOperations } from "../utils/graphqlClient";
+import TableFilters from "./TableFilters";
 
 export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) {
   const [brands, setBrands] = useState([]);
+  const [filteredBrands, setFilteredBrands] = useState([]);
   const [query, setQuery] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -12,10 +15,14 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
       setIsLoading(true);
       carBrandOperations
         .getAllCarBrands()
-        .then((data) => setBrands(data || []))
+        .then((data) => {
+          setBrands(data || []);
+          setFilteredBrands(data || []);
+        })
         .catch((err) => {
           console.error("Error fetching brands:", err);
           setBrands([]);
+          setFilteredBrands([]);
         })
         .finally(() => setIsLoading(false));
     }
@@ -23,7 +30,7 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
 
   if (!isOpen) return null;
 
-  const filtered = brands.filter((b) =>
+  const filtered = filteredBrands.filter((b) =>
     b.Name.toLowerCase().includes(query.toLowerCase())
   );
 
@@ -41,7 +48,7 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
             </svg>
           </button>
         </div>
-        <div className="flex space-x-2">
+        <div className="flex space-x-2 items-center">
           <input
             type="text"
             value={query}
@@ -49,7 +56,36 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
             className="flex-1 border rounded px-3 py-2"
             placeholder="Nombre de marca..."
           />
+          <button
+            type="button"
+            onClick={() => setShowFilters(true)}
+            className="px-3 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 text-sm"
+          >
+            Mostrar Filtros
+          </button>
         </div>
+        {showFilters && (
+          <div className="fixed inset-0 bg-black bg-opacity-40 flex items-start justify-center pt-10 z-60">
+            <div className="bg-white rounded-md shadow-lg p-4 w-full max-w-xl space-y-4">
+              <div className="flex justify-between items-center pb-2 border-b">
+                <h4 className="text-lg font-semibold">Filtros</h4>
+                <button
+                  onClick={() => setShowFilters(false)}
+                  className="text-gray-500 hover:text-gray-700"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              <TableFilters
+                modelName="carbrands"
+                data={brands}
+                onFilterChange={setFilteredBrands}
+              />
+            </div>
+          </div>
+        )}
         <div className="max-h-80 overflow-y-auto">
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50 sticky top-0">

--- a/frontend/src/pages/CarCreate.jsx
+++ b/frontend/src/pages/CarCreate.jsx
@@ -115,53 +115,59 @@ export default function CarCreate({ onClose, onSave, car: initialCar = null }) {
             <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Auto' : 'Nuevo Auto'}</h2>
             {error && <div className="text-red-600 mb-2">{error}</div>}
             <form onSubmit={handleSubmit} className="space-y-4">
-                <div className="relative">
-                    <label className="block text-sm font-medium mb-1">Marca</label>
-                    <select name="carBrandID" value={form.carBrandID} onChange={handleChange} className="w-full border p-2 rounded" required>
-                        <option value="">Seleccione</option>
-                        {brands.map(b => <option key={b.CarBrandID} value={b.CarBrandID}>{b.Name}</option>)}
-                    </select>
-                    <button type="button" onClick={() => setShowBrandModal(true)} className="absolute right-2 top-8 text-gray-500 hover:text-gray-700">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                        </svg>
-                    </button>
-                </div>
-                <div className="relative">
-                    <label className="block text-sm font-medium mb-1">Modelo</label>
-                    <select name="carModelID" value={form.carModelID} onChange={handleChange} className="w-full border p-2 rounded" required disabled={!form.carBrandID}>
-                        <option value="">Seleccione</option>
-                        {models.map(m => <option key={m.CarModelID} value={m.CarModelID}>{m.Model}</option>)}
-                    </select>
-                    <button type="button" onClick={() => setShowModelModal(true)} className="absolute right-2 top-8 text-gray-500 hover:text-gray-700">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                        </svg>
-                    </button>
-                </div>
-                <div className="relative">
-                    <label className="block text-sm font-medium mb-1">Cliente</label>
-                    <select name="clientID" value={form.clientID} onChange={handleChange} className="w-full border p-2 rounded" required>
-                        <option value="">Seleccione</option>
-                        {clients.map(c => <option key={c.ClientID} value={c.ClientID}>{c.FirstName} {c.LastName}</option>)}
-                    </select>
-                    <button type="button" onClick={() => setShowClientModal(true)} className="absolute right-2 top-8 text-gray-500 hover:text-gray-700">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                        </svg>
-                    </button>
+                <div>
+                    <label htmlFor="carBrandID" className="block text-sm font-medium mb-1">Marca</label>
+                    <div className="flex items-center space-x-2">
+                        <select id="carBrandID" name="carBrandID" value={form.carBrandID} onChange={handleChange} className="flex-1 border p-2 rounded" required>
+                            <option value="">Seleccione</option>
+                            {brands.map(b => <option key={b.CarBrandID} value={b.CarBrandID}>{b.Name}</option>)}
+                        </select>
+                        <button type="button" onClick={() => setShowBrandModal(true)} className="text-gray-500 hover:text-gray-700">
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                        </button>
+                    </div>
                 </div>
                 <div>
-                    <label className="block text-sm font-medium mb-1">Patente</label>
-                    <input type="text" name="licensePlate" value={form.licensePlate} onChange={handleChange} className="w-full border p-2 rounded" required />
+                    <label htmlFor="carModelID" className="block text-sm font-medium mb-1">Modelo</label>
+                    <div className="flex items-center space-x-2">
+                        <select id="carModelID" name="carModelID" value={form.carModelID} onChange={handleChange} className="flex-1 border p-2 rounded" required disabled={!form.carBrandID}>
+                            <option value="">Seleccione</option>
+                            {models.map(m => <option key={m.CarModelID} value={m.CarModelID}>{m.Model}</option>)}
+                        </select>
+                        <button type="button" onClick={() => setShowModelModal(true)} className="text-gray-500 hover:text-gray-700">
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                        </button>
+                    </div>
                 </div>
                 <div>
-                    <label className="block text-sm font-medium mb-1">Año</label>
-                    <input type="number" name="year" value={form.year} onChange={handleChange} className="w-full border p-2 rounded" />
+                    <label htmlFor="clientID" className="block text-sm font-medium mb-1">Cliente</label>
+                    <div className="flex items-center space-x-2">
+                        <select id="clientID" name="clientID" value={form.clientID} onChange={handleChange} className="flex-1 border p-2 rounded" required>
+                            <option value="">Seleccione</option>
+                            {clients.map(c => <option key={c.ClientID} value={c.ClientID}>{c.FirstName} {c.LastName}</option>)}
+                        </select>
+                        <button type="button" onClick={() => setShowClientModal(true)} className="text-gray-500 hover:text-gray-700">
+                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                        </button>
+                    </div>
                 </div>
                 <div>
-                    <label className="block text-sm font-medium mb-1">Kilometraje último servicio</label>
-                    <input type="number" name="lastServiceMileage" value={form.lastServiceMileage} onChange={handleChange} className="w-full border p-2 rounded" />
+                    <label htmlFor="licensePlate" className="block text-sm font-medium mb-1">Patente</label>
+                    <input id="licensePlate" type="text" name="licensePlate" value={form.licensePlate} onChange={handleChange} className="w-full border p-2 rounded" required />
+                </div>
+                <div>
+                    <label htmlFor="year" className="block text-sm font-medium mb-1">Año</label>
+                    <input id="year" type="number" name="year" value={form.year} onChange={handleChange} className="w-full border p-2 rounded" />
+                </div>
+                <div>
+                    <label htmlFor="lastServiceMileage" className="block text-sm font-medium mb-1">Kilometraje último servicio</label>
+                    <input id="lastServiceMileage" type="number" name="lastServiceMileage" value={form.lastServiceMileage} onChange={handleChange} className="w-full border p-2 rounded" />
                 </div>
                 <div>
                     <label className="inline-flex items-center">


### PR DESCRIPTION
## Summary
- open filter panels in overlay modals for brand/model/client search
- associate select labels with their fields in car creation form

## Testing
- `npm run lint` *(fails: many unused vars across repo)*

------
https://chatgpt.com/codex/tasks/task_e_6869820e5cc88323984990feee88d58f