### PR TITLE
Fix car CRUD modal behavior

### DIFF
--- a/frontend/src/components/CarBrandSearchModal.jsx
+++ b/frontend/src/components/CarBrandSearchModal.jsx
@@ -66,7 +66,7 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
         </div>
         {showFilters && (
           <div className="fixed inset-0 bg-black bg-opacity-40 flex items-start justify-center pt-10 z-60">
-            <div className="bg-white rounded-md shadow-lg p-4 w-full max-w-xl space-y-4">
+          <div className="bg-white rounded-md shadow-lg p-4 w-full max-w-xl space-y-4 max-h-[80vh] overflow-y-auto">
               <div className="flex justify-between items-center pb-2 border-b">
                 <h4 className="text-lg font-semibold">Filtros</h4>
                 <button
@@ -98,7 +98,14 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
             <tbody className="bg-white divide-y divide-gray-200">
               {filtered.length > 0 ? (
                 filtered.map((b) => (
-                  <tr key={b.CarBrandID} className="hover:bg-gray-50">
+                  <tr
+                    key={b.CarBrandID}
+                    className="hover:bg-gray-50"
+                    onDoubleClick={() => {
+                      onBrandSelect(b);
+                      onClose();
+                    }}
+                  >
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">{b.CarBrandID}</td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">{b.Name}</td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm font-medium">
@@ -107,7 +114,7 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
                           onBrandSelect(b);
                           onClose();
                         }}
-                        className="text-indigo-600 hover:text-indigo-900"
+                        className="text-indigo-600 hover:text-indigo-900 px-2 py-1 text-sm"
                       >
                         Seleccionar
                       </button>

--- a/frontend/src/components/CarModelSearchModal.jsx
+++ b/frontend/src/components/CarModelSearchModal.jsx
@@ -75,7 +75,7 @@ export default function CarModelSearchModal({
         </div>
         {showFilters && (
           <div className="fixed inset-0 bg-black bg-opacity-40 flex items-start justify-center pt-10 z-60">
-            <div className="bg-white rounded-md shadow-lg p-4 w-full max-w-xl space-y-4">
+          <div className="bg-white rounded-md shadow-lg p-4 w-full max-w-xl space-y-4 max-h-[80vh] overflow-y-auto">
               <div className="flex justify-between items-center pb-2 border-b">
                 <h4 className="text-lg font-semibold">Filtros</h4>
                 <button
@@ -108,7 +108,14 @@ export default function CarModelSearchModal({
             <tbody className="bg-white divide-y divide-gray-200">
               {filtered.length > 0 ? (
                 filtered.map((m) => (
-                  <tr key={m.CarModelID} className="hover:bg-gray-50">
+                  <tr
+                    key={m.CarModelID}
+                    className="hover:bg-gray-50"
+                    onDoubleClick={() => {
+                      onModelSelect(m);
+                      onClose();
+                    }}
+                  >
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">{m.CarModelID}</td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">{m.Model}</td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
@@ -120,7 +127,7 @@ export default function CarModelSearchModal({
                           onModelSelect(m);
                           onClose();
                         }}
-                        className="text-indigo-600 hover:text-indigo-900"
+                        className="text-indigo-600 hover:text-indigo-900 px-2 py-1 text-sm"
                       >
                         Seleccionar
                       </button>

--- a/frontend/src/components/ClientSearchModal.jsx
+++ b/frontend/src/components/ClientSearchModal.jsx
@@ -80,7 +80,7 @@ export default function ClientSearchModal({ isOpen, onClose, onClientSelect }) {
         </div>
         {showFilters && (
           <div className="fixed inset-0 bg-black bg-opacity-40 flex items-start justify-center pt-10 z-60">
-            <div className="bg-white rounded-md shadow-lg p-4 w-full max-w-xl space-y-4">
+            <div className="bg-white rounded-md shadow-lg p-4 w-full max-w-xl space-y-4 max-h-[80vh] overflow-y-auto">
               <div className="flex justify-between items-center pb-2 border-b">
                 <h4 className="text-lg font-semibold">Filtros</h4>
                 <button
@@ -121,15 +121,22 @@ export default function ClientSearchModal({ isOpen, onClose, onClientSelect }) {
             <tbody className="bg-white divide-y divide-gray-200">
               {filtered.length > 0 ? (
                 filtered.map((c) => (
-                  <tr key={c.clientID} className="hover:bg-gray-50">
+                  <tr
+                    key={c.ClientID}
+                    className="hover:bg-gray-50"
+                    onDoubleClick={() => {
+                      onClientSelect(c);
+                      onClose();
+                    }}
+                  >
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
-                      {c.clientID}
+                      {c.ClientID}
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
-                      {c.firstName} {c.lastName || ""}
+                      {c.FirstName} {c.LastName || ""}
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
-                      {c.docNumber || ""}
+                      {c.DocNumber || ""}
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm font-medium">
                       <button
@@ -137,7 +144,7 @@ export default function ClientSearchModal({ isOpen, onClose, onClientSelect }) {
                           onClientSelect(c);
                           onClose();
                         }}
-                        className="text-indigo-600 hover:text-indigo-900"
+                        className="text-indigo-600 hover:text-indigo-900 px-2 py-1 text-sm"
                       >
                         Seleccionar
                       </button>


### PR DESCRIPTION
## Summary
- open car forms in popup windows instead of modals
- allow double‑click selection in car search modals and fix client fields
- add scrolling to filter overlays

## Testing
- `npm run lint` *(fails: 97 problems)*

------
https://chatgpt.com/codex/tasks/task_e_686987e719688323aff4583bf889f805