### PR TITLE
Improve item and subcategory display

### DIFF
--- a/app/graphql/resolvers/itemsubcategories.py
+++ b/app/graphql/resolvers/itemsubcategories.py
@@ -2,13 +2,9 @@
 import strawberry
 from typing import List, Optional
 from app.graphql.schemas.itemsubcategories import ItemSubcategoriesInDB
-from app.graphql.crud.itemsubcategories import (
-    get_itemsubcategories,
-    get_itemsubcategories_by_id,
-    get_itemsubcategories_by_category_id,  # AGREGADO
-)
+from app.models.itemsubcategories import ItemSubcategories
 from app.db import get_db
-from app.utils import list_to_schema, obj_to_schema
+from sqlalchemy.orm import joinedload
 from strawberry.types import Info
 
 
@@ -19,8 +15,18 @@ class ItemsubcategoriesQuery:
         db_gen = get_db()
         db = next(db_gen)
         try:
-            records = get_itemsubcategories(db)
-            return list_to_schema(ItemSubcategoriesInDB, records)
+            records = db.query(ItemSubcategories).options(
+                joinedload(ItemSubcategories.itemCategories_)
+            ).all()
+            result = []
+            for r in records:
+                result.append(ItemSubcategoriesInDB(
+                    ItemSubcategoryID=r.ItemSubcategoryID,
+                    ItemCategoryID=r.ItemCategoryID,
+                    SubcategoryName=r.SubcategoryName,
+                    CategoryName=getattr(r.itemCategories_, 'CategoryName', None)
+                ))
+            return result
         finally:
             db_gen.close()
 
@@ -29,8 +35,17 @@ class ItemsubcategoriesQuery:
         db_gen = get_db()
         db = next(db_gen)
         try:
-            record = get_itemsubcategories_by_id(db, id)
-            return obj_to_schema(ItemSubcategoriesInDB, record) if record else None
+            record = db.query(ItemSubcategories).options(
+                joinedload(ItemSubcategories.itemCategories_)
+            ).filter(ItemSubcategories.ItemSubcategoryID == id).first()
+            if not record:
+                return None
+            return ItemSubcategoriesInDB(
+                ItemSubcategoryID=record.ItemSubcategoryID,
+                ItemCategoryID=record.ItemCategoryID,
+                SubcategoryName=record.SubcategoryName,
+                CategoryName=getattr(record.itemCategories_, 'CategoryName', None)
+            )
         finally:
             db_gen.close()
 
@@ -41,8 +56,18 @@ class ItemsubcategoriesQuery:
         db_gen = get_db()
         db = next(db_gen)
         try:
-            records = get_itemsubcategories_by_category_id(db, categoryID)
-            return list_to_schema(ItemSubcategoriesInDB, records)
+            records = db.query(ItemSubcategories).options(
+                joinedload(ItemSubcategories.itemCategories_)
+            ).filter(ItemSubcategories.ItemCategoryID == categoryID).all()
+            result = []
+            for r in records:
+                result.append(ItemSubcategoriesInDB(
+                    ItemSubcategoryID=r.ItemSubcategoryID,
+                    ItemCategoryID=r.ItemCategoryID,
+                    SubcategoryName=r.SubcategoryName,
+                    CategoryName=getattr(r.itemCategories_, 'CategoryName', None)
+                ))
+            return result
         finally:
             db_gen.close()
 

--- a/app/graphql/schemas/items.py
+++ b/app/graphql/schemas/items.py
@@ -60,6 +60,9 @@ class ItemsInDB:
     LastModified: Optional[date]  # Corregido nombre del campo (era lastModified)
     WarehouseID: int
     IsActive: bool
+    BrandName: Optional[str] = None
+    CategoryName: Optional[str] = None
+    SubcategoryName: Optional[str] = None
 
 
 

--- a/app/graphql/schemas/itemsubcategories.py
+++ b/app/graphql/schemas/itemsubcategories.py
@@ -17,3 +17,4 @@ class ItemSubcategoriesInDB:
     ItemSubcategoryID: int
     ItemCategoryID: int
     SubcategoryName: str
+    CategoryName: Optional[str] = None

--- a/app/utils/item_helpers.py
+++ b/app/utils/item_helpers.py
@@ -1,0 +1,58 @@
+# app/utils/item_helpers.py
+
+from typing import Any, Optional
+from app.graphql.schemas.items import ItemsInDB
+
+
+def safe_int(value: Any, default: int = 0) -> int:
+    """Convierte de forma segura cualquier valor a int"""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def safe_str(value: Any, default: str = "") -> str:
+    """Convierte de forma segura cualquier valor a str"""
+    try:
+        return str(value) if value is not None else default
+    except Exception:
+        return default
+
+
+def safe_bool(value: Any, default: bool = False) -> bool:
+    """Convierte de forma segura cualquier valor a bool"""
+    try:
+        return bool(value)
+    except Exception:
+        return default
+
+
+def item_to_in_db(item) -> ItemsInDB:
+    """Convierte un modelo Items a ItemsInDB incluyendo nombres relacionados"""
+    brand_name = safe_str(getattr(getattr(item, 'brands_', None), 'Name', None), None)
+    category_name = safe_str(getattr(getattr(item, 'itemCategories_', None), 'CategoryName', None), None)
+    subcategory_name = safe_str(getattr(getattr(item, 'itemSubcategories_', None), 'SubcategoryName', None), None)
+
+    data = {
+        'ItemID': safe_int(getattr(item, 'ItemID', 0)),
+        'CompanyID': safe_int(getattr(item, 'CompanyID', 0)),
+        'BranchID': safe_int(getattr(item, 'BranchID', 0)),
+        'BrandID': safe_int(getattr(item, 'BrandID', 0)),
+        'Code': safe_str(getattr(item, 'Code', '')),
+        'Description': safe_str(getattr(item, 'Description', '')),
+        'ItemCategoryID': safe_int(getattr(item, 'ItemCategoryID', 0)),
+        'ItemSubcategoryID': safe_int(getattr(item, 'ItemSubcategoryID', 0)),
+        'SupplierID': safe_int(getattr(item, 'SupplierID', 0)),
+        'ControlStock': safe_bool(getattr(item, 'ControlStock', False)),
+        'ReplenishmentStock': safe_int(getattr(item, 'ReplenishmentStock', 0)),
+        'IsOffer': safe_bool(getattr(item, 'IsOffer', False)),
+        'OEM': safe_str(getattr(item, 'OEM', None), None),
+        'LastModified': getattr(item, 'LastModified', None),
+        'WarehouseID': safe_int(getattr(item, 'WarehouseID', 0)),
+        'IsActive': safe_bool(getattr(item, 'IsActive', False)),
+        'BrandName': brand_name,
+        'CategoryName': category_name,
+        'SubcategoryName': subcategory_name,
+    }
+    return ItemsInDB(**data)


### PR DESCRIPTION
## Summary
- show related names for item subcategories
- include brand, category and subcategory names when listing items
- share item conversion helper and adjust global search

## Testing
- `python -m py_compile app/utils/item_helpers.py app/graphql/resolvers/items.py app/graphql/resolvers/itemsubcategories.py app/graphql/schemas/items.py app/graphql/schemas/itemsubcategories.py app/graphql/schema.py`

------
https://chatgpt.com/codex/tasks/task_e_6869a854483483239da317e0f0b2d1d8