### PR TITLE
Standardize car creation form

### DIFF
--- a/frontend/src/pages/Cars.jsx
+++ b/frontend/src/pages/Cars.jsx
@@ -104,7 +104,7 @@ export default function Cars() {
         openReactWindow(
             (popup) => (
                 <CarCreate
-                    car={c}
+                    initialData={c}
                     onSave={() => {
                         popup.opener.postMessage('reload-cars', '*');
                         popup.close();

--- a/frontend/src/utils/graphqlClient.js
+++ b/frontend/src/utils/graphqlClient.js
@@ -248,6 +248,49 @@ export const QUERIES = {
         }
     `,
 
+    // FORMULARIO DE PROVEEDORES
+    GET_SUPPLIER_FORM_DATA: `
+        query GetSupplierFormData {
+            docTypes: allDoctypes {
+                DocTypeID
+                Name
+            }
+            countries: allCountries {
+                CountryID
+                Name
+            }
+            provinces: allProvinces {
+                ProvinceID
+                CountryID
+                Name
+            }
+        }
+    `,
+
+    // FORMULARIO DE AUTOS
+    GET_CAR_FORM_DATA: `
+        query GetCarFormData {
+            carBrands: allCarbrands {
+                CarBrandID
+                Name
+            }
+            carModels: allCarmodels {
+                CarModelID
+                CarBrandID
+                Model
+            }
+            clients: allClients {
+                ClientID
+                FirstName
+                LastName
+            }
+            discounts: allDiscounts {
+                DiscountID
+                DiscountName
+            }
+        }
+    `,
+
     // ITEMS
     GET_ALL_ITEMS: `
         query GetAllItems {
@@ -1401,7 +1444,7 @@ export const supplierOperations = {
     // Obtener datos para formulario de proveedor
     async getSupplierFormData() {
         try {
-            const data = await graphqlClient.query(QUERIES.GET_CLIENT_FORM_DATA);
+            const data = await graphqlClient.query(QUERIES.GET_SUPPLIER_FORM_DATA);
             return {
                 documentTypes: data.docTypes || [],
                 countries: data.countries || [],
@@ -1607,6 +1650,21 @@ export const carOperations = {
             return data.allCars || [];
         } catch (error) {
             console.error("Error obteniendo autos:", error);
+            throw error;
+        }
+    },
+
+    async getCarFormData() {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_CAR_FORM_DATA);
+            return {
+                carBrands: data.carBrands || [],
+                carModels: data.carModels || [],
+                clients: data.clients || [],
+                discounts: data.discounts || []
+            };
+        } catch (error) {
+            console.error("Error obteniendo datos del formulario de autos:", error);
             throw error;
         }
     },


### PR DESCRIPTION
## Summary
- add supplier and car form queries
- implement car form data helper
- update CarCreate page to use helper
- pass initialData correctly from Cars page

## Testing
- `npm run lint` *(fails: eslint errors)*
- `npm test` in frontend (prints "No tests specified")

------
https://chatgpt.com/codex/tasks/task_e_6869d746c9908323a8cc5dfddb40fc42