### PR TITLE
Fix default selection behavior in CRUD dropdowns

### DIFF
--- a/frontend/src/pages/CarCreate.jsx
+++ b/frontend/src/pages/CarCreate.jsx
@@ -38,15 +38,6 @@ export default function CarCreate({ initialData = null, onClose, onSave }) {
             setLoadingForm(true);
             const data = await carOperations.getCarFormData();
             setFormData(data);
-            if (!isEdit) {
-                setCar(prev => ({
-                    ...prev,
-                    carBrandID: data.carBrands[0]?.CarBrandID || '',
-                    carModelID: data.carModels[0]?.CarModelID || '',
-                    clientID: data.clients[0]?.ClientID || '',
-                    discountID: data.discounts[0]?.DiscountID || ''
-                }));
-            }
         } catch (err) {
             console.error('Error cargando datos del formulario:', err);
             setError('Error cargando los datos del formulario: ' + err.message);

--- a/frontend/src/pages/CreditCardCreate.jsx
+++ b/frontend/src/pages/CreditCardCreate.jsx
@@ -3,7 +3,7 @@ import { creditCardOperations, creditCardGroupOperations } from "../utils/graphq
 
 export default function CreditCardCreate({ onClose, onSave, card: initialCard = null }) {
     const [card, setCard] = useState({
-        CreditCardGroupID: 0,
+        CreditCardGroupID: "",
         CardName: "",
         Surcharge: 0,
         Installments: 0,
@@ -24,9 +24,6 @@ export default function CreditCardCreate({ onClose, onSave, card: initialCard = 
             setLoadingForm(true);
             const data = await creditCardGroupOperations.getAllGroups();
             setGroups(data);
-            if (data.length > 0 && !initialCard) {
-                setCard(c => ({ ...c, CreditCardGroupID: data[0].CreditCardGroupID }));
-            }
         } finally {
             setLoadingForm(false);
         }
@@ -49,7 +46,11 @@ export default function CreditCardCreate({ onClose, onSave, card: initialCard = 
         const { name, value, type, checked } = e.target;
         setCard(prev => ({
             ...prev,
-            [name]: type === 'checkbox' ? checked : (name.includes('ID') || name === 'Installments') ? parseInt(value) || 0 : value
+            [name]: type === 'checkbox'
+                ? checked
+                : (name.includes('ID') || name === 'Installments')
+                    ? (value === '' ? '' : parseInt(value))
+                    : value
         }));
     };
 
@@ -90,6 +91,7 @@ export default function CreditCardCreate({ onClose, onSave, card: initialCard = 
                         onChange={handleChange}
                         className="w-full border border-gray-300 p-2 rounded"
                     >
+                        <option value="">Seleccione</option>
                         {groups.map(g => (
                             <option key={g.CreditCardGroupID} value={g.CreditCardGroupID}>{g.GroupName}</option>
                         ))}

--- a/frontend/src/pages/SaleConditionCreate.jsx
+++ b/frontend/src/pages/SaleConditionCreate.jsx
@@ -5,7 +5,7 @@ export default function SaleConditionCreate({ onClose, onSave, saleCondition: in
     const [name, setName] = useState("");
     const [dueDate, setDueDate] = useState("");
     const [surcharge, setSurcharge] = useState(0);
-    const [creditCardID, setCreditCardID] = useState(0);
+    const [creditCardID, setCreditCardID] = useState("");
     const [cards, setCards] = useState([]);
     const [isActive, setIsActive] = useState(true);
     const [loading, setLoading] = useState(false);
@@ -18,9 +18,6 @@ export default function SaleConditionCreate({ onClose, onSave, saleCondition: in
             try {
                 const data = await creditCardOperations.getAllCards();
                 setCards(data);
-                if (data.length > 0 && !initialSC) {
-                    setCreditCardID(data[0].CreditCardID);
-                }
             } finally {
                 setLoadingForm(false);
             }
@@ -35,7 +32,7 @@ export default function SaleConditionCreate({ onClose, onSave, saleCondition: in
             setDueDate(initialSC.DueDate || "");
             setSurcharge(initialSC.Surcharge || 0);
             setIsActive(initialSC.IsActive !== false);
-            setCreditCardID(initialSC.CreditCardID || 0);
+            setCreditCardID(initialSC.CreditCardID ? initialSC.CreditCardID : "");
         }
     }, [initialSC]);
 
@@ -104,9 +101,10 @@ export default function SaleConditionCreate({ onClose, onSave, saleCondition: in
                     <label className="block text-sm font-medium mb-1">Tarjeta de Crédito</label>
                     <select
                         value={creditCardID}
-                        onChange={(e) => setCreditCardID(parseInt(e.target.value))}
+                        onChange={(e) => setCreditCardID(e.target.value === "" ? "" : parseInt(e.target.value))}
                         className="w-full border border-gray-300 p-2 rounded"
                     >
+                        <option value="">Seleccione</option>
                         {cards.map(card => (
                             <option key={card.CreditCardID} value={card.CreditCardID}>{card.CardName}</option>
                         ))}

--- a/frontend/src/pages/SupplierCreate.jsx
+++ b/frontend/src/pages/SupplierCreate.jsx
@@ -3,7 +3,7 @@ import { supplierOperations } from "../utils/graphqlClient";
 
 export default function SupplierCreate({ onClose, onSave, supplier: initialSupplier = null }) {
     const [supplier, setSupplier] = useState({
-        docTypeID: 1,
+        docTypeID: "",
         docNumber: "",
         firstName: "",
         lastName: "",
@@ -13,8 +13,8 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
         city: "",
         postalCode: "",
         isActive: true,
-        countryID: 1,
-        provinceID: 1,
+        countryID: "",
+        provinceID: "",
     });
 
     const [formData, setFormData] = useState({
@@ -33,14 +33,6 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
             setLoadingForm(true);
             const data = await supplierOperations.getSupplierFormData();
             setFormData(data);
-            if (!isEdit && data.documentTypes.length > 0) {
-                setSupplier(prev => ({
-                    ...prev,
-                    docTypeID: data.documentTypes[0].DocTypeID,
-                    countryID: data.countries[0]?.CountryID || 1,
-                    provinceID: data.provinces[0]?.ProvinceID || 1,
-                }));
-            }
         } catch (err) {
             console.error("Error cargando datos del formulario:", err);
             setError("Error cargando los datos del formulario: " + err.message);
@@ -57,7 +49,7 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
         if (initialSupplier) {
             setIsEdit(true);
             setSupplier({
-                docTypeID: parseInt(initialSupplier.DocTypeID) || 1,
+                docTypeID: initialSupplier.DocTypeID ? parseInt(initialSupplier.DocTypeID) : "",
                 docNumber: initialSupplier.DocNumber || "",
                 firstName: initialSupplier.FirstName || "",
                 lastName: initialSupplier.LastName || "",
@@ -67,8 +59,8 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
                 city: initialSupplier.City || "",
                 postalCode: initialSupplier.PostalCode || "",
                 isActive: initialSupplier.IsActive !== false,
-                countryID: parseInt(initialSupplier.CountryID) || 1,
-                provinceID: parseInt(initialSupplier.ProvinceID) || 1,
+                countryID: initialSupplier.CountryID ? parseInt(initialSupplier.CountryID) : "",
+                provinceID: initialSupplier.ProvinceID ? parseInt(initialSupplier.ProvinceID) : "",
             });
         }
     }, [initialSupplier]);
@@ -79,7 +71,7 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
         if (type === "checkbox") {
             processedValue = checked;
         } else if (name.includes("ID")) {
-            processedValue = parseInt(value) || 0;
+            processedValue = value === "" ? "" : parseInt(value);
         } else {
             processedValue = value;
         }
@@ -88,14 +80,10 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
             [name]: processedValue,
         }));
         if (name === "countryID") {
-            const provs = formData.provinces.filter(p => p.CountryID === parseInt(value));
-            if (provs.length > 0) {
-                setSupplier(prev => ({
-                    ...prev,
-                    countryID: parseInt(value),
-                    provinceID: provs[0].ProvinceID,
-                }));
-            }
+            setSupplier(prev => ({
+                ...prev,
+                provinceID: "",
+            }));
         }
     };
 
@@ -159,6 +147,7 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
                                 className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                                 required
                             >
+                                <option value="">Seleccione</option>
                                 {formData.documentTypes.map(dt => (
                                     <option key={dt.DocTypeID} value={dt.DocTypeID}>{dt.Name}</option>
                                 ))}
@@ -262,6 +251,7 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
                                     className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                                     required
                                 >
+                                    <option value="">Seleccione</option>
                                     {formData.countries.map(c => (
                                         <option key={c.CountryID} value={c.CountryID}>{c.Name}</option>
                                     ))}
@@ -276,6 +266,7 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
                                     className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                                     required
                                 >
+                                    <option value="">Seleccione</option>
                                     {availableProvinces.length > 0 ? (
                                         availableProvinces.map(p => (
                                             <option key={p.ProvinceID} value={p.ProvinceID}>{p.Name}</option>


### PR DESCRIPTION
## Summary
- avoid preselecting values in car form
- remove automatic selections from supplier form and handle blank states
- ensure sale condition and credit card forms don't default to first option

## Testing
- `npm test`
- `python -m pytest tests/` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869e536b188832392f84e7be58b17d9