### PR TITLE
Fix useCallback warnings in forms

### DIFF
--- a/frontend/src/pages/CarCreate.jsx
+++ b/frontend/src/pages/CarCreate.jsx
@@ -44,7 +44,7 @@ export default function CarCreate({ initialData = null, onClose, onSave }) {
         } finally {
             setLoadingForm(false);
         }
-    }, [isEdit]);
+    }, []);
 
     useEffect(() => {
         loadFormData();

--- a/frontend/src/pages/ClientCreate.jsx
+++ b/frontend/src/pages/ClientCreate.jsx
@@ -55,7 +55,7 @@ export default function ClientCreate({
         } finally {
             setLoadingForm(false);
         }
-    }, [isEdit]);
+    }, []);
 
     // Cargar datos del formulario al montar el componente
     useEffect(() => {


### PR DESCRIPTION
## Summary
- remove unneeded `isEdit` dependency from `useCallback` in `CarCreate.jsx`
- remove unneeded `isEdit` dependency from `useCallback` in `ClientCreate.jsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6869ed31010c83239f041f9d201814e2