### PR TITLE
Fix PriceLists attribute name

### DIFF
--- a/app/graphql/crud/pricelists.py
+++ b/app/graphql/crud/pricelists.py
@@ -9,7 +9,7 @@ def get_pricelists(db: Session):
 
 
 def get_pricelists_by_id(db: Session, pricelistid: int):
-    return db.query(PriceLists).filter(PriceLists.priceListID == pricelistid).first()
+    return db.query(PriceLists).filter(PriceLists.PriceListID == pricelistid).first()
 
 
 def create_pricelists(db: Session, data: PriceListsCreate):


### PR DESCRIPTION
## Summary
- correct attribute name used in `get_pricelists_by_id`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `pyright`


------
https://chatgpt.com/codex/tasks/task_e_6869f844c4f083239dc9f081ca7ce36c