### PR TITLE
Implement order creation module with GraphQL

### DIFF
--- a/app/graphql/mutations/orders.py
+++ b/app/graphql/mutations/orders.py
@@ -1,0 +1,40 @@
+# app/graphql/mutations/orders.py
+import strawberry
+from typing import Optional
+from app.graphql.schemas.orders import OrdersCreate, OrdersUpdate, OrdersInDB
+from app.graphql.crud.orders import create_orders, update_orders, delete_orders
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+@strawberry.type
+class OrdersMutations:
+    @strawberry.mutation
+    def create_order(self, info: Info, data: OrdersCreate) -> OrdersInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            obj = create_orders(db, data)
+            return obj_to_schema(OrdersInDB, obj)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_order(self, info: Info, orderID: int, data: OrdersUpdate) -> Optional[OrdersInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated = update_orders(db, orderID, data)
+            return obj_to_schema(OrdersInDB, updated) if updated else None
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_order(self, info: Info, orderID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_orders(db, orderID)
+            return deleted is not None
+        finally:
+            db_gen.close()

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -63,6 +63,7 @@ from app.graphql.mutations.carmodels import CarModelsMutations
 from app.graphql.mutations.cars import CarsMutations
 from app.graphql.mutations.warehouses import WarehousesMutations
 from app.graphql.mutations.pricelists import PricelistsMutations
+from app.graphql.mutations.orders import OrdersMutations
 
 # IMPORTANTE: Importar las clases de autenticación correctamente
 from app.graphql.resolvers.auth import AuthQuery
@@ -348,6 +349,7 @@ class Mutation(
     CreditCardsMutations,
     WarehousesMutations,
     PricelistsMutations,
+    OrdersMutations,
 ):
     """Mutaciones principales"""
     

--- a/frontend/src/utils/graphqlClient.js
+++ b/frontend/src/utils/graphqlClient.js
@@ -235,6 +235,34 @@ export const QUERIES = {
         }
     `,
 
+    // SERVICETYPES
+    GET_ALL_SERVICETYPES: `
+        query GetAllServicetypes {
+            allServicetypes {
+                ServiceTypeID
+                Type
+            }
+        }
+    `,
+    GET_SERVICETYPE_BY_ID: `
+        query GetServicetypeById($id: Int!) {
+            servicetypesById(id: $id) {
+                ServiceTypeID
+                Type
+            }
+        }
+    `,
+
+    // ORDER STATUS
+    GET_ALL_ORDERSTATUS: `
+        query GetAllOrderstatus {
+            allOrderstatus {
+                OrderStatusID
+                Status
+            }
+        }
+    `,
+
     GET_VENDORS: `
         query GetVendors {
             allVendors {
@@ -1160,6 +1188,14 @@ export const MUTATIONS = {
     DELETE_WAREHOUSE: `
         mutation DeleteWarehouse($warehouseID: Int!) {
             deleteWarehouse(warehouseID: $warehouseID)
+        }
+    `,
+
+    CREATE_ORDER: `
+        mutation CreateOrder($input: OrdersCreate!) {
+            createOrder(data: $input) {
+                OrderID
+            }
         }
     `
 };
@@ -2196,6 +2232,31 @@ export const warehouseOperations = {
     async deleteWarehouse(id) {
         const data = await graphqlClient.mutation(MUTATIONS.DELETE_WAREHOUSE, { warehouseID: id });
         return data.deleteWarehouse;
+    }
+};
+
+export const serviceTypeOperations = {
+    async getAllServicetypes() {
+        const data = await graphqlClient.query(QUERIES.GET_ALL_SERVICETYPES);
+        return data.allServicetypes || [];
+    },
+    async getServicetypeById(id) {
+        const data = await graphqlClient.query(QUERIES.GET_SERVICETYPE_BY_ID, { id });
+        return data.servicetypesById;
+    }
+};
+
+export const orderStatusOperations = {
+    async getAllOrderstatus() {
+        const data = await graphqlClient.query(QUERIES.GET_ALL_ORDERSTATUS);
+        return data.allOrderstatus || [];
+    }
+};
+
+export const orderOperations = {
+    async createOrder(orderData) {
+        const data = await graphqlClient.mutation(MUTATIONS.CREATE_ORDER, { input: orderData });
+        return data.createOrder;
     }
 };
 


### PR DESCRIPTION
## Summary
- add GraphQL mutations for orders
- register OrdersMutations in schema
- add service type and order status queries, create order mutation and helpers to GraphQL client
- update OrderCreate page to use GraphQL operations
- update item search modal to fetch data via GraphQL

## Testing
- `npm run lint` *(fails: many unused vars)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869fa566ca4832385112c624ca57684