### PR TITLE
Fix order routing and popup windows

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ import SaleConditions from "./pages/SaleConditions";
 import CreditCardGroups from "./pages/CreditCardGroups";
 import CreditCards from "./pages/CreditCards";
 import Documents from "./pages/Documents";
+import Orders from "./pages/Orders";
 import Layout from "./components/Layout";
 import RequireAuth from "./components/RequireAuth";
 import LogoutSuccess from "./pages/LogoutSuccess";
@@ -204,6 +205,7 @@ export default function App() {
                     <Route path="carmodels" element={<CarModels />} />
                     <Route path="cars" element={<Cars />} />
                     <Route path="documents" element={<Documents />} />
+                    <Route path="orders" element={<Orders />} />
                     {/* Ruta fallback: todo lo desconocido a dashboard */}
                     <Route path="*" element={<Navigate to="/dashboard" replace />} />
                 </Route>

--- a/frontend/src/components/MyWindowPortal.jsx
+++ b/frontend/src/components/MyWindowPortal.jsx
@@ -7,6 +7,7 @@ export default function MyWindowPortal({
   title = "Ventana",
   width = 800,
   height = 600,
+  existingWindow = null,
 }) {
   const containerRef = useRef(document.createElement("div"));
   const newWindow = useRef(null);
@@ -16,12 +17,13 @@ export default function MyWindowPortal({
     const left = window.screenX + 100;
     const top = window.screenY + 100;
 
-    newWindow.current = window.open(
-      "",
-      title,
-      `width=${width},height=${height},left=${left},top=${top}`
-    );
-    console.log(newWindow.current);
+    newWindow.current =
+      existingWindow ||
+      window.open(
+        "",
+        title,
+        `width=${width},height=${height},left=${left},top=${top}`
+      );
     if (newWindow.current) {
       newWindow.current.document.title = title;
 

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -51,8 +51,24 @@ export default function Sidebar() {
         const tempOrderId = `temp-${Date.now()}-${Math.floor(
             Math.random() * 1000
         )}`;
+        const left = window.screenX + 100;
+        const top = window.screenY + 100;
+        const win = window.open(
+            "",
+            title,
+            `width=${width},height=${height},left=${left},top=${top}`
+        );
+        if (!win) {
+            alert("La ventana emergente fue bloqueada por el navegador.");
+            return;
+        }
         setPopup(
-            <MyWindowPortal title={title} width={width} height={height}>
+            <MyWindowPortal
+                title={title}
+                width={width}
+                height={height}
+                existingWindow={win}
+            >
                 <Component tempOrderId={tempOrderId} />
             </MyWindowPortal>
         );


### PR DESCRIPTION
## Summary
- keep opened popup window from being blocked
- update `Sidebar` to pass newly opened window to `MyWindowPortal`
- expose `orders` page route

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `(cd frontend && npm run lint)` *(fails: missing eslint-plugin-react-refresh)*

------
https://chatgpt.com/codex/tasks/task_e_686a0064f50883239142aed31c7f3f4e