### PR TITLE
Fix items not loaded on order edit

### DIFF
--- a/app/models/orders.py
+++ b/app/models/orders.py
@@ -87,3 +87,9 @@ class Orders(Base):
     orderDetails: Mapped[List['OrderDetails']] = relationship('OrderDetails', back_populates='orders_')
     orderHistory: Mapped[List['OrderHistory']] = relationship('OrderHistory', back_populates='orders_')
     tempOrderDetails: Mapped[List['TempOrderDetails']] = relationship('TempOrderDetails', back_populates='orders_')
+
+    @property
+    def Items(self) -> List['OrderDetails']:
+        """Alias de acceso para los detalles de la orden."""
+        return self.orderDetails
+

--- a/frontend/src/pages/OrderCreate.jsx
+++ b/frontend/src/pages/OrderCreate.jsx
@@ -83,6 +83,23 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
                 priceListId: String(initialOrder.PriceListID || ""),
                 warehouseId: String(initialOrder.WarehouseID || "")
             });
+
+            orderOperations
+                .getOrderById(initialOrder.OrderID)
+                .then((ord) => {
+                    if (ord && ord.Items) {
+                        const parsed = ord.Items.map((d) => ({
+                            itemID: d.ItemID,
+                            code: "",
+                            description: d.Description || "",
+                            quantity: d.Quantity,
+                            price: d.UnitPrice,
+                            subtotal: d.Quantity * d.UnitPrice,
+                        }));
+                        setItems(parsed);
+                    }
+                })
+                .catch(() => {});
         }
     }, [initialOrder]);
 

--- a/frontend/src/utils/graphqlClient.js
+++ b/frontend/src/utils/graphqlClient.js
@@ -482,6 +482,13 @@ export const QUERIES = {
                 PriceListID
                 OrderStatusID
                 WarehouseID
+                Items {
+                    OrderDetailID
+                    ItemID
+                    Quantity
+                    UnitPrice
+                    Description
+                }
             }
         }
     `,


### PR DESCRIPTION
## Summary
- expose order items via `Orders.Items`
- include order items in the `GET_ORDER_BY_ID` query
- load order items when editing orders

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686cbc6b44ac832394160bc97ff82540