### PR TITLE
Fix order deletion cascade

### DIFF
--- a/app/graphql/crud/orders.py
+++ b/app/graphql/crud/orders.py
@@ -66,6 +66,8 @@ def update_orders(db: Session, orderid: int, data: OrdersUpdate):
 def delete_orders(db: Session, orderid: int):
     obj = get_orders_by_id(db, orderid)
     if obj:
+        # Delete associated order details first to avoid foreign key issues
+        db.query(OrderDetails).filter(OrderDetails.OrderID == orderid).delete(synchronize_session=False)
         db.delete(obj)
         db.commit()
     return obj


### PR DESCRIPTION
## Summary
- avoid SQL constraint error when deleting orders by removing associated order details first

## Testing
- `pytest -q`
- `npm run lint` *(fails: many unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_686cbf18b7d08323b16656306da78f04