### PR TITLE
Add delete actions to master data pages

### DIFF
--- a/frontend/src/pages/ItemCategories.jsx
+++ b/frontend/src/pages/ItemCategories.jsx
@@ -74,6 +74,16 @@ export default function ItemCategories() {
         );
     };
 
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar categoría?')) return;
+        try {
+            await itemCategoryOperations.deleteItemCategory(id);
+            loadCategories();
+        } catch (err) {
+            alert('Error al borrar categoría: ' + err.message);
+        }
+    };
+
     return (
         <div className="p-6">
             <div className="flex items-center justify-between mb-6">
@@ -113,7 +123,10 @@ export default function ItemCategories() {
                     {categories.map(cat => (
                         <div key={cat.ItemCategoryID} className="bg-white rounded shadow p-4">
                             <h3 className="text-lg font-semibold mb-2">{cat.CategoryName}</h3>
-                            <button onClick={() => handleEdit(cat)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(cat)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(cat.ItemCategoryID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
                         </div>
                     ))}
                 </div>

--- a/frontend/src/pages/ItemSubcategories.jsx
+++ b/frontend/src/pages/ItemSubcategories.jsx
@@ -73,6 +73,16 @@ export default function ItemSubcategories() {
         );
     };
 
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar subcategoría?')) return;
+        try {
+            await itemSubcategoryOperations.deleteItemSubcategory(id);
+            loadSubcategories();
+        } catch (err) {
+            alert('Error al borrar subcategoría: ' + err.message);
+        }
+    };
+
     return (
         <div className="p-6">
             <div className="flex items-center justify-between mb-6">
@@ -113,7 +123,10 @@ export default function ItemSubcategories() {
                         <div key={sc.ItemSubcategoryID} className="bg-white rounded shadow p-4">
                             <h3 className="text-lg font-semibold mb-2">{sc.SubcategoryName}</h3>
                             <p className="text-sm mb-2">Categoría: {sc.CategoryName}</p>
-                            <button onClick={() => handleEdit(sc)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(sc)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(sc.ItemSubcategoryID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
                         </div>
                     ))}
                 </div>

--- a/frontend/src/pages/Items.jsx
+++ b/frontend/src/pages/Items.jsx
@@ -73,6 +73,16 @@ export default function Items() {
         );
     };
 
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar ítem?')) return;
+        try {
+            await itemOperations.deleteItem(id);
+            loadItems();
+        } catch (err) {
+            alert('Error al borrar ítem: ' + err.message);
+        }
+    };
+
     return (
         <div className="p-6">
             <div className="flex items-center justify-between mb-6">
@@ -113,7 +123,10 @@ export default function Items() {
                         <div key={it.ItemID} className="bg-white rounded shadow p-4">
                             <h3 className="text-lg font-semibold mb-2">{it.Description}</h3>
                             <p className="text-sm mb-2">Código: {it.Code}</p>
-                            <button onClick={() => handleEdit(it)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(it)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(it.ItemID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
                         </div>
                     ))}
                 </div>

--- a/frontend/src/pages/PriceLists.jsx
+++ b/frontend/src/pages/PriceLists.jsx
@@ -74,6 +74,16 @@ export default function PriceLists() {
         );
     };
 
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar lista de precios?')) return;
+        try {
+            await pricelistOperations.deletePricelist(id);
+            loadLists();
+        } catch (err) {
+            alert('Error al borrar lista de precios: ' + err.message);
+        }
+    };
+
     return (
         <div className="p-6">
             <div className="flex items-center justify-between mb-6">
@@ -115,7 +125,10 @@ export default function PriceLists() {
                             <h3 className="text-lg font-semibold mb-2">{pl.Name}</h3>
                             <p className="text-sm mb-2">{pl.Description}</p>
                             <p className="text-sm mb-2">Activo: {pl.IsActive ? 'Sí' : 'No'}</p>
-                            <button onClick={() => handleEdit(pl)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(pl)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(pl.PriceListID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
                         </div>
                     ))}
                 </div>

--- a/frontend/src/pages/Suppliers.jsx
+++ b/frontend/src/pages/Suppliers.jsx
@@ -119,6 +119,16 @@ export default function Suppliers() {
         );
     };
 
+    const handleDeleteSupplier = async (id) => {
+        if (!confirm('¿Borrar proveedor?')) return;
+        try {
+            await supplierOperations.deleteSupplier(id);
+            loadSuppliers();
+        } catch (err) {
+            alert('Error al borrar proveedor: ' + err.message);
+        }
+    };
+
     const handleViewDetails = (supplier) => {
         setSelectedSupplier(supplier);
     };
@@ -256,6 +266,9 @@ export default function Suppliers() {
                                     </button>
                                     <button onClick={() => handleEditSupplier(supplier)} className="px-3 py-2 bg-gray-100 text-gray-700 text-sm rounded hover:bg-gray-200">
                                         Editar
+                                    </button>
+                                    <button onClick={() => handleDeleteSupplier(supplier.SupplierID)} className="px-3 py-2 bg-red-600 text-white text-sm rounded hover:bg-red-700">
+                                        Eliminar
                                     </button>
                                 </div>
                             </div>

--- a/frontend/src/pages/Warehouses.jsx
+++ b/frontend/src/pages/Warehouses.jsx
@@ -74,6 +74,16 @@ export default function Warehouses() {
         );
     };
 
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar depósito?')) return;
+        try {
+            await warehouseOperations.deleteWarehouse(id);
+            loadWarehouses();
+        } catch (err) {
+            alert('Error al borrar depósito: ' + err.message);
+        }
+    };
+
     return (
         <div className="p-6">
             <div className="flex items-center justify-between mb-6">
@@ -114,7 +124,10 @@ export default function Warehouses() {
                         <div key={wh.WarehouseID} className="bg-white rounded shadow p-4">
                             <h3 className="text-lg font-semibold mb-2">{wh.Name}</h3>
                             <p className="text-sm mb-2">{wh.Addres}</p>
-                            <button onClick={() => handleEdit(wh)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(wh)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(wh.WarehouseID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
                         </div>
                     ))}
                 </div>


### PR DESCRIPTION
## Summary
- allow deleting item categories from the list
- add deletion for item subcategories
- support deleting items
- enable deleting suppliers
- allow deleting price lists and warehouses

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ce0b527d88323b51c0a30e03fb648