### PR TITLE
Add delete actions across catalog pages

### DIFF
--- a/frontend/src/pages/Brands.jsx
+++ b/frontend/src/pages/Brands.jsx
@@ -73,6 +73,16 @@ export default function Brands() {
         );
     };
 
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar marca?')) return;
+        try {
+            await brandOperations.deleteBrand(id);
+            loadBrands();
+        } catch (err) {
+            alert('Error al borrar marca: ' + err.message);
+        }
+    };
+
     return (
         <div className="p-6">
             <div className="flex items-center justify-between mb-6">
@@ -113,7 +123,10 @@ export default function Brands() {
                         <div key={br.BrandID} className="bg-white rounded shadow p-4">
                             <h3 className="text-lg font-semibold mb-2">{br.Name}</h3>
                             <p className="text-sm mb-2">Activo: {br.IsActive ? 'Sí' : 'No'}</p>
-                            <button onClick={() => handleEdit(br)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(br)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(br.BrandID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
                         </div>
                     ))}
                 </div>

--- a/frontend/src/pages/CarBrands.jsx
+++ b/frontend/src/pages/CarBrands.jsx
@@ -73,6 +73,16 @@ export default function CarBrands() {
         );
     };
 
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar marca de auto?')) return;
+        try {
+            await carBrandOperations.deleteCarBrand(id);
+            loadCarBrands();
+        } catch (err) {
+            alert('Error al borrar marca de auto: ' + err.message);
+        }
+    };
+
     return (
         <div className="p-6">
             <div className="flex items-center justify-between mb-6">
@@ -112,7 +122,10 @@ export default function CarBrands() {
                     {carBrands.map(cb => (
                         <div key={cb.CarBrandID} className="bg-white rounded shadow p-4">
                             <h3 className="text-lg font-semibold mb-2">{cb.Name}</h3>
-                            <button onClick={() => handleEdit(cb)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(cb)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(cb.CarBrandID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
                         </div>
                     ))}
                 </div>

--- a/frontend/src/pages/CarModels.jsx
+++ b/frontend/src/pages/CarModels.jsx
@@ -71,6 +71,16 @@ export default function CarModels() {
         );
     };
 
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar modelo de auto?')) return;
+        try {
+            await carModelOperations.deleteCarModel(id);
+            loadModels();
+        } catch (err) {
+            alert('Error al borrar modelo de auto: ' + err.message);
+        }
+    };
+
     return (
         <div className="p-6">
             <div className="flex items-center justify-between mb-6">
@@ -97,7 +107,10 @@ export default function CarModels() {
                         <div key={m.CarModelID} className="bg-white rounded shadow p-4">
                             <h3 className="text-lg font-semibold mb-2">{m.Model}</h3>
                             <p className="text-sm mb-2">Marca: {m.CarBrandName}</p>
-                            <button onClick={() => handleEdit(m)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(m)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(m.CarModelID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
                         </div>
                     ))}
                 </div>

--- a/frontend/src/pages/Cars.jsx
+++ b/frontend/src/pages/Cars.jsx
@@ -116,6 +116,16 @@ export default function Cars() {
         );
     };
 
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar auto?')) return;
+        try {
+            await carOperations.deleteCar(id);
+            loadCars();
+        } catch (err) {
+            alert('Error al borrar auto: ' + err.message);
+        }
+    };
+
     // Cleanup de filtros al desmontar
     useEffect(() => {
         return () => {
@@ -267,12 +277,18 @@ export default function Cars() {
                                     )}
                                 </div>
 
-                                <div className="mt-4 pt-4 border-t border-gray-200">
+                                <div className="mt-4 pt-4 border-t border-gray-200 flex space-x-2">
                                     <button
                                         onClick={() => handleEdit(c)}
-                                        className="w-full px-3 py-2 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 transition-colors"
+                                        className="flex-1 px-3 py-2 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 transition-colors"
                                     >
                                         Editar Auto
+                                    </button>
+                                    <button
+                                        onClick={() => handleDelete(c.CarID)}
+                                        className="px-3 py-2 bg-red-600 text-white text-sm rounded hover:bg-red-700"
+                                    >
+                                        Eliminar
                                     </button>
                                 </div>
                             </div>

--- a/frontend/src/pages/CreditCardGroups.jsx
+++ b/frontend/src/pages/CreditCardGroups.jsx
@@ -72,6 +72,16 @@ export default function CreditCardGroups() {
         );
     };
 
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar grupo?')) return;
+        try {
+            await creditCardGroupOperations.deleteGroup(id);
+            loadGroups();
+        } catch (err) {
+            alert('Error al borrar grupo: ' + err.message);
+        }
+    };
+
     return (
         <div className="p-6">
             <div className="flex items-center justify-between mb-6">
@@ -111,7 +121,10 @@ export default function CreditCardGroups() {
                     {groups.map(g => (
                         <div key={g.CreditCardGroupID} className="bg-white rounded shadow p-4">
                             <h3 className="text-lg font-semibold mb-2">{g.GroupName}</h3>
-                            <button onClick={() => handleEdit(g)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(g)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(g.CreditCardGroupID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
                         </div>
                     ))}
                 </div>

--- a/frontend/src/pages/CreditCards.jsx
+++ b/frontend/src/pages/CreditCards.jsx
@@ -72,6 +72,16 @@ export default function CreditCards() {
         );
     };
 
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar tarjeta?')) return;
+        try {
+            await creditCardOperations.deleteCard(id);
+            loadCards();
+        } catch (err) {
+            alert('Error al borrar tarjeta: ' + err.message);
+        }
+    };
+
     return (
         <div className="p-6">
             <div className="flex items-center justify-between mb-6">
@@ -114,7 +124,10 @@ export default function CreditCards() {
                             <p className="text-sm">Grupo: {c.GroupName}</p>
                             <p className="text-sm">Recargo: {c.Surcharge}</p>
                             <p className="text-sm mb-2">Activo: {c.IsActive ? 'Sí' : 'No'}</p>
-                            <button onClick={() => handleEdit(c)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(c)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(c.CreditCardID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
                         </div>
                     ))}
                 </div>

--- a/frontend/src/pages/SaleConditions.jsx
+++ b/frontend/src/pages/SaleConditions.jsx
@@ -86,6 +86,16 @@ export default function SaleConditions() {
         );
     };
 
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar condición?')) return;
+        try {
+            await saleConditionOperations.deleteSaleCondition(id);
+            loadSCs();
+        } catch (err) {
+            alert('Error al borrar condición: ' + err.message);
+        }
+    };
+
     return (
         <div className="p-6">
             <div className="flex items-center justify-between mb-6">
@@ -134,7 +144,10 @@ export default function SaleConditions() {
                                 </p>
                                 <p className="text-sm mb-1">Vencimiento: {sc.DueDate}</p>
                                 <p className="text-sm mb-2">Activo: {sc.IsActive ? 'Sí' : 'No'}</p>
-                                <button onClick={() => handleEdit(sc)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <div className="flex space-x-2">
+                                    <button onClick={() => handleEdit(sc)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                    <button onClick={() => handleDelete(sc.SaleConditionID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                                </div>
                             </div>
                         );
                     })}


### PR DESCRIPTION
## Summary
- enable deleting brands, card groups, cards, sale conditions, car brands, car models and cars

## Testing
- `npm run lint` *(fails: no-unused-vars across repo)*

------
https://chatgpt.com/codex/tasks/task_e_686ce70c527883238ff678aa43fb78e8