### PR TITLE
Add user management menu and pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,9 @@ import CreditCardGroups from "./pages/CreditCardGroups";
 import CreditCards from "./pages/CreditCards";
 import Documents from "./pages/Documents";
 import Orders from "./pages/Orders";
+import Roles from "./pages/Roles";
+import Users from "./pages/Users";
+import RolesUsers from "./pages/RolesUsers";
 import Layout from "./components/Layout";
 import RequireAuth from "./components/RequireAuth";
 import LogoutSuccess from "./pages/LogoutSuccess";
@@ -206,6 +209,9 @@ export default function App() {
                     <Route path="cars" element={<Cars />} />
                     <Route path="documents" element={<Documents />} />
                     <Route path="orders" element={<Orders />} />
+                    <Route path="roles" element={<Roles />} />
+                    <Route path="users" element={<Users />} />
+                    <Route path="rolesusers" element={<RolesUsers />} />
                     {/* Ruta fallback: todo lo desconocido a dashboard */}
                     <Route path="*" element={<Navigate to="/dashboard" replace />} />
                 </Route>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -108,14 +108,14 @@ export default function Sidebar() {
             items: [
                 { label: "Sucursales", to: "/branches" },
                 { label: "Empresa", to: "/companydata" },
-            ],
-        },
-        {
-            title: "Usuarios y Seguridad",
-            items: [
-                { label: "Usuarios", to: "/users" },
-                { label: "roles", to: "/roles" },
-                { label: "Registro de actividad", to: "/useractivitylog" },
+                { label: "Roles", to: "/roles" },
+                {
+                    label: "Usuarios",
+                    submenu: [
+                        { label: "Usuarios", to: "/users" },
+                        { label: "Roles y Usuarios", to: "/rolesusers" },
+                    ],
+                },
             ],
         },
     ];

--- a/frontend/src/pages/Roles.jsx
+++ b/frontend/src/pages/Roles.jsx
@@ -1,0 +1,49 @@
+// frontend/src/pages/Roles.jsx
+import { useEffect, useState } from "react";
+import { roleOperations } from "../utils/graphqlClient";
+
+export default function Roles() {
+    const [roles, setRoles] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const loadRoles = async () => {
+        try {
+            setLoading(true);
+            const data = await roleOperations.getAllRoles();
+            setRoles(data);
+        } catch (err) {
+            console.error("Error cargando roles:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => { loadRoles(); }, []);
+
+    return (
+        <div className="p-6">
+            <h1 className="text-3xl font-bold mb-4">Roles</h1>
+            {loading ? (
+                <p>Cargando...</p>
+            ) : error ? (
+                <p className="text-red-600">{error}</p>
+            ) : (
+                <ul className="space-y-2">
+                    {roles.map((r) => (
+                        <li key={r.RoleID} className="border p-2 rounded">
+                            <strong>{r.RoleName}</strong> (ID: {r.RoleID})
+                        </li>
+                    ))}
+                </ul>
+            )}
+            <button
+                onClick={loadRoles}
+                className="mt-4 px-4 py-2 bg-blue-600 text-white rounded"
+            >
+                Recargar
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/pages/RolesUsers.jsx
+++ b/frontend/src/pages/RolesUsers.jsx
@@ -1,0 +1,49 @@
+// frontend/src/pages/RolesUsers.jsx
+import { useEffect, useState } from "react";
+import { userAccessOperations } from "../utils/graphqlClient";
+
+export default function RolesUsers() {
+    const [records, setRecords] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const loadData = async () => {
+        try {
+            setLoading(true);
+            const data = await userAccessOperations.getAllUserAccess();
+            setRecords(data);
+        } catch (err) {
+            console.error("Error cargando asignaciones:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => { loadData(); }, []);
+
+    return (
+        <div className="p-6">
+            <h1 className="text-3xl font-bold mb-4">Roles y Usuarios</h1>
+            {loading ? (
+                <p>Cargando...</p>
+            ) : error ? (
+                <p className="text-red-600">{error}</p>
+            ) : (
+                <ul className="space-y-2">
+                    {records.map((r, idx) => (
+                        <li key={idx} className="border p-2 rounded">
+                            Usuario: {r.UserID} - Compañía: {r.CompanyID} - Sucursal: {r.BranchID} - Rol: {r.RoleID}
+                        </li>
+                    ))}
+                </ul>
+            )}
+            <button
+                onClick={loadData}
+                className="mt-4 px-4 py-2 bg-blue-600 text-white rounded"
+            >
+                Recargar
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/pages/Users.jsx
+++ b/frontend/src/pages/Users.jsx
@@ -1,0 +1,50 @@
+// frontend/src/pages/Users.jsx
+import { useEffect, useState } from "react";
+import { userOperations } from "../utils/graphqlClient";
+
+export default function Users() {
+    const [users, setUsers] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const loadUsers = async () => {
+        try {
+            setLoading(true);
+            const data = await userOperations.getAllUsers();
+            setUsers(data);
+        } catch (err) {
+            console.error("Error cargando usuarios:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => { loadUsers(); }, []);
+
+    return (
+        <div className="p-6">
+            <h1 className="text-3xl font-bold mb-4">Usuarios</h1>
+            {loading ? (
+                <p>Cargando...</p>
+            ) : error ? (
+                <p className="text-red-600">{error}</p>
+            ) : (
+                <ul className="space-y-2">
+                    {users.map((u) => (
+                        <li key={u.UserID} className="border p-2 rounded">
+                            <strong>{u.FullName}</strong> ({u.Nickname}) - ID:{" "}
+                            {u.UserID}
+                        </li>
+                    ))}
+                </ul>
+            )}
+            <button
+                onClick={loadUsers}
+                className="mt-4 px-4 py-2 bg-blue-600 text-white rounded"
+            >
+                Recargar
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/utils/graphqlClient.js
+++ b/frontend/src/utils/graphqlClient.js
@@ -296,6 +296,28 @@ export const QUERIES = {
         }
     `,
 
+    // ROLES
+    GET_ALL_ROLES: `
+        query GetAllRoles {
+            allRoles {
+                RoleID
+                RoleName
+            }
+        }
+    `,
+
+    // ROLES Y USUARIOS (UserAccess)
+    GET_ALL_USERACCESS: `
+        query GetAllUseraccess {
+            allUseraccess {
+                UserID
+                CompanyID
+                BranchID
+                RoleID
+            }
+        }
+    `,
+
     // COMBOS PARA FORMULARIOS
     GET_CLIENT_FORM_DATA: `
         query GetClientFormData {
@@ -1842,6 +1864,30 @@ export const userOperations = {
             return data.usersById;
         } catch (error) {
             console.error("Error obteniendo usuario:", error);
+            throw error;
+        }
+    }
+};
+
+export const roleOperations = {
+    async getAllRoles() {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_ALL_ROLES);
+            return data.allRoles || [];
+        } catch (error) {
+            console.error("Error obteniendo roles:", error);
+            throw error;
+        }
+    }
+};
+
+export const userAccessOperations = {
+    async getAllUserAccess() {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_ALL_USERACCESS);
+            return data.allUseraccess || [];
+        } catch (error) {
+            console.error("Error obteniendo roles y usuarios:", error);
             throw error;
         }
     }


### PR DESCRIPTION
## Summary
- create Roles.jsx, Users.jsx and RolesUsers.jsx pages
- support roles and user access queries in `graphqlClient`
- expose role and user access operations
- integrate user management pages in sidebar and route setup

## Testing
- `npm test --silent --prefix frontend`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686f2cca8cac8323aa997c8607c3d31e