### PR TITLE
Add user management improvements

### DIFF
--- a/app/graphql/crud/branches.py
+++ b/app/graphql/crud/branches.py
@@ -12,6 +12,11 @@ def get_branches_by_id(db: Session, branchID: int):
     return db.query(Branches).filter(Branches.BranchID == branchID).first()
 
 
+def get_branches_by_company(db: Session, company_id: int):
+    """Retrieve branches filtered by CompanyID"""
+    return db.query(Branches).filter(Branches.CompanyID == company_id).all()
+
+
 def create_branches(db: Session, data: BranchesCreate):
     obj = Branches(**vars(data))
     db.add(obj)

--- a/app/graphql/resolvers/branches.py
+++ b/app/graphql/resolvers/branches.py
@@ -3,7 +3,11 @@ import base64
 import strawberry
 from typing import List, Optional
 from app.graphql.schemas.branches import BranchesInDB
-from app.graphql.crud.branches import get_branches, get_branches_by_id
+from app.graphql.crud.branches import (
+    get_branches,
+    get_branches_by_id,
+    get_branches_by_company,
+)
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
 from strawberry.types import Info
@@ -43,6 +47,22 @@ class BranchesQuery:
             data = item.__dict__.copy()
             data["logo"] = encode_logo(data.get("logo"))
             return BranchesInDB(**data)
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def branches_by_company(self, info: Info, companyID: int) -> List[BranchesInDB]:
+        """Obtener sucursales filtradas por CompanyID"""
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            branches = get_branches_by_company(db, companyID)
+            result = []
+            for item in branches:
+                data = item.__dict__.copy()
+                data["logo"] = encode_logo(data.get("logo"))
+                result.append(BranchesInDB(**data))
+            return result
         finally:
             db_gen.close()
 

--- a/app/graphql/schemas/users.py
+++ b/app/graphql/schemas/users.py
@@ -9,8 +9,9 @@ class UsersInDB:
     UserID: int
     Nickname: Optional[str] = None
     FullName: Optional[str] = None
+    Password: Optional[str] = None
     RoleID: Optional[int] = None
-    IsActive: Optional[bool] = None 
+    IsActive: Optional[bool] = None
 
 
 @strawberry.input
@@ -19,6 +20,8 @@ class UserCreate:
     UserID: int
     Nickname: Optional[str] = None
     FullName: Optional[str] = None
+    Password: Optional[str] = None
+    IsActive: Optional[bool] = None
     RoleID: Optional[int] = None
 
 
@@ -28,4 +31,6 @@ class UserUpdate:
     UserID: int
     Nickname: Optional[str] = None
     FullName: Optional[str] = None
+    Password: Optional[str] = None
+    IsActive: Optional[bool] = None
     RoleID: Optional[int] = None

--- a/frontend/src/pages/Roles.jsx
+++ b/frontend/src/pages/Roles.jsx
@@ -3,16 +3,20 @@ import { useEffect, useState } from "react";
 import { roleOperations } from "../utils/graphqlClient";
 import RoleForm from "./RoleForm";
 import { openReactWindow } from "../utils/openReactWindow";
+import TableFilters from "../components/TableFilters";
 
 export default function Roles() {
+    const [allRoles, setAllRoles] = useState([]);
     const [roles, setRoles] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
 
     const loadRoles = async () => {
         try {
             setLoading(true);
             const data = await roleOperations.getAllRoles();
+            setAllRoles(data);
             setRoles(data);
         } catch (err) {
             console.error("Error cargando roles:", err);
@@ -33,6 +37,10 @@ export default function Roles() {
         window.addEventListener('message', handler);
         return () => window.removeEventListener('message', handler);
     }, []);
+
+    const handleFilterChange = (filtered) => {
+        setRoles(filtered);
+    };
 
     const handleCreate = () => {
         openReactWindow(
@@ -77,7 +85,34 @@ export default function Roles() {
 
     return (
         <div className="p-6">
-            <h1 className="text-3xl font-bold mb-4">Roles</h1>
+            <div className="flex items-center justify-between mb-4">
+                <h1 className="text-3xl font-bold">Roles</h1>
+                <div className="flex space-x-2">
+                    <button
+                        onClick={() => setShowFilters(!showFilters)}
+                        className="px-4 py-2 bg-purple-600 text-white rounded"
+                    >
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button
+                        onClick={loadRoles}
+                        className="px-4 py-2 bg-blue-600 text-white rounded"
+                    >
+                        Recargar
+                    </button>
+                    <button
+                        onClick={handleCreate}
+                        className="px-4 py-2 bg-green-600 text-white rounded"
+                    >
+                        Nuevo Rol
+                    </button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters modelName="roles" data={allRoles} onFilterChange={handleFilterChange} />
+                </div>
+            )}
             {loading ? (
                 <p>Cargando...</p>
             ) : error ? (
@@ -97,20 +132,6 @@ export default function Roles() {
                     ))}
                 </ul>
             )}
-            <div className="mt-4 space-x-2">
-                <button
-                    onClick={loadRoles}
-                    className="px-4 py-2 bg-blue-600 text-white rounded"
-                >
-                    Recargar
-                </button>
-                <button
-                    onClick={handleCreate}
-                    className="px-4 py-2 bg-green-600 text-white rounded"
-                >
-                    Nuevo Rol
-                </button>
-            </div>
         </div>
     );
 }

--- a/frontend/src/pages/RolesUsers.jsx
+++ b/frontend/src/pages/RolesUsers.jsx
@@ -3,16 +3,20 @@ import { useEffect, useState } from "react";
 import { userAccessOperations } from "../utils/graphqlClient";
 import UserAccessForm from "./UserAccessForm";
 import { openReactWindow } from "../utils/openReactWindow";
+import TableFilters from "../components/TableFilters";
 
 export default function RolesUsers() {
+    const [allRecords, setAllRecords] = useState([]);
     const [records, setRecords] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
 
     const loadData = async () => {
         try {
             setLoading(true);
             const data = await userAccessOperations.getAllUserAccess();
+            setAllRecords(data);
             setRecords(data);
         } catch (err) {
             console.error("Error cargando asignaciones:", err);
@@ -33,6 +37,10 @@ export default function RolesUsers() {
         window.addEventListener('message', handler);
         return () => window.removeEventListener('message', handler);
     }, []);
+
+    const handleFilterChange = (filtered) => {
+        setRecords(filtered);
+    };
 
     const handleCreate = () => {
         openReactWindow(
@@ -82,7 +90,25 @@ export default function RolesUsers() {
 
     return (
         <div className="p-6">
-            <h1 className="text-3xl font-bold mb-4">Roles y Usuarios</h1>
+            <div className="flex items-center justify-between mb-4">
+                <h1 className="text-3xl font-bold">Roles y Usuarios</h1>
+                <div className="flex space-x-2">
+                    <button onClick={() => setShowFilters(!showFilters)} className="px-4 py-2 bg-purple-600 text-white rounded">
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button onClick={loadData} className="px-4 py-2 bg-blue-600 text-white rounded">
+                        Recargar
+                    </button>
+                    <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded">
+                        Nueva Asignación
+                    </button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters modelName="useraccess" data={allRecords} onFilterChange={handleFilterChange} />
+                </div>
+            )}
             {loading ? (
                 <p>Cargando...</p>
             ) : error ? (
@@ -102,20 +128,6 @@ export default function RolesUsers() {
                     ))}
                 </ul>
             )}
-            <div className="mt-4 space-x-2">
-                <button
-                    onClick={loadData}
-                    className="px-4 py-2 bg-blue-600 text-white rounded"
-                >
-                    Recargar
-                </button>
-                <button
-                    onClick={handleCreate}
-                    className="px-4 py-2 bg-green-600 text-white rounded"
-                >
-                    Nueva Asignación
-                </button>
-            </div>
         </div>
     );
 }

--- a/frontend/src/pages/UserForm.jsx
+++ b/frontend/src/pages/UserForm.jsx
@@ -5,6 +5,8 @@ import { userOperations } from "../utils/graphqlClient";
 export default function UserForm({ onClose, onSave, user: initialUser = null }) {
     const [nickname, setNickname] = useState("");
     const [fullName, setFullName] = useState("");
+    const [password, setPassword] = useState("");
+    const [isActive, setIsActive] = useState(true);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
     const [isEdit, setIsEdit] = useState(false);
@@ -14,6 +16,7 @@ export default function UserForm({ onClose, onSave, user: initialUser = null }) 
             setIsEdit(true);
             setNickname(initialUser.Nickname || "");
             setFullName(initialUser.FullName || "");
+            setIsActive(initialUser.IsActive);
         }
     }, [initialUser]);
 
@@ -26,12 +29,16 @@ export default function UserForm({ onClose, onSave, user: initialUser = null }) 
             if (isEdit) {
                 result = await userOperations.updateUser(initialUser.UserID, {
                     Nickname: nickname,
-                    FullName: fullName
+                    FullName: fullName,
+                    Password: password || undefined,
+                    IsActive: isActive
                 });
             } else {
                 result = await userOperations.createUser({
                     Nickname: nickname,
-                    FullName: fullName
+                    FullName: fullName,
+                    Password: password,
+                    IsActive: isActive
                 });
             }
             onSave && onSave(result);
@@ -68,6 +75,26 @@ export default function UserForm({ onClose, onSave, user: initialUser = null }) 
                         className="w-full border border-gray-300 p-2 rounded"
                         required
                     />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Password</label>
+                    <input
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        className="w-full border border-gray-300 p-2 rounded"
+                        required={!isEdit}
+                    />
+                </div>
+                <div className="flex items-center space-x-2">
+                    <input
+                        id="isActive"
+                        type="checkbox"
+                        checked={isActive}
+                        onChange={(e) => setIsActive(e.target.checked)}
+                        className="h-4 w-4"
+                    />
+                    <label htmlFor="isActive" className="text-sm">Activo</label>
                 </div>
                 <div className="flex justify-end space-x-4 pt-4 border-t">
                     <button

--- a/frontend/src/pages/Users.jsx
+++ b/frontend/src/pages/Users.jsx
@@ -3,16 +3,20 @@ import { useEffect, useState } from "react";
 import { userOperations } from "../utils/graphqlClient";
 import UserForm from "./UserForm";
 import { openReactWindow } from "../utils/openReactWindow";
+import TableFilters from "../components/TableFilters";
 
 export default function Users() {
+    const [allUsers, setAllUsers] = useState([]);
     const [users, setUsers] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
 
     const loadUsers = async () => {
         try {
             setLoading(true);
             const data = await userOperations.getAllUsers();
+            setAllUsers(data);
             setUsers(data);
         } catch (err) {
             console.error("Error cargando usuarios:", err);
@@ -33,6 +37,10 @@ export default function Users() {
         window.addEventListener('message', handler);
         return () => window.removeEventListener('message', handler);
     }, []);
+
+    const handleFilterChange = (filtered) => {
+        setUsers(filtered);
+    };
 
     const handleCreate = () => {
         openReactWindow(
@@ -77,7 +85,34 @@ export default function Users() {
 
     return (
         <div className="p-6">
-            <h1 className="text-3xl font-bold mb-4">Usuarios</h1>
+            <div className="flex items-center justify-between mb-4">
+                <h1 className="text-3xl font-bold">Usuarios</h1>
+                <div className="flex space-x-2">
+                    <button
+                        onClick={() => setShowFilters(!showFilters)}
+                        className="px-4 py-2 bg-purple-600 text-white rounded"
+                    >
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button
+                        onClick={loadUsers}
+                        className="px-4 py-2 bg-blue-600 text-white rounded"
+                    >
+                        Recargar
+                    </button>
+                    <button
+                        onClick={handleCreate}
+                        className="px-4 py-2 bg-green-600 text-white rounded"
+                    >
+                        Nuevo Usuario
+                    </button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters modelName="users" data={allUsers} onFilterChange={handleFilterChange} />
+                </div>
+            )}
             {loading ? (
                 <p>Cargando...</p>
             ) : error ? (
@@ -97,20 +132,6 @@ export default function Users() {
                     ))}
                 </ul>
             )}
-            <div className="mt-4 space-x-2">
-                <button
-                    onClick={loadUsers}
-                    className="px-4 py-2 bg-blue-600 text-white rounded"
-                >
-                    Recargar
-                </button>
-                <button
-                    onClick={handleCreate}
-                    className="px-4 py-2 bg-green-600 text-white rounded"
-                >
-                    Nuevo Usuario
-                </button>
-            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- implement query to fetch branches by company
- include password and active state in user GraphQL schema
- add filters to user and role lists
- add dropdown form for assigning user roles with search
- extend user form with password and active checkbox

## Testing
- `npm run lint` *(fails: no-unused-vars)*
- `npx pyright` *(failed: npm error)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686f39ee85608323a0b796c03923fc17