### PR TITLE
Fix updateUser to include ID in input

### DIFF
--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -256,7 +256,11 @@ export const userOperations = {
 
     async updateUser(id, userData) {
         try {
-            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_USER_RECORD, { userID: id, input: userData });
+            // El esquema UserUpdate exige incluir el ID dentro del input
+            const data = await graphqlClient.mutation(
+                MUTATIONS.UPDATE_USER_RECORD,
+                { userID: id, input: { UserID: id, ...userData } }
+            );
             return data.updateUserRecord;
         } catch (error) {
             console.error("Error actualizando usuario:", error);


### PR DESCRIPTION
## Summary
- include `UserID` in the input object when updating a user so it matches the backend schema

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6870933201d083239cc16383463b361f