### PR TITLE
Muestra nombres en listados de roles-usuarios

### DIFF
--- a/app/graphql/resolvers/useraccess.py
+++ b/app/graphql/resolvers/useraccess.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from app.graphql.schemas.useraccess import UserAccessInDB
 from app.graphql.crud.useraccess import get_useraccess, get_useraccess_by_id
 from app.db import get_db
-from app.utils import list_to_schema, obj_to_schema
+
 from strawberry.types import Info
 
 
@@ -16,7 +16,20 @@ class UseraccessQuery:
         db = next(db_gen)
         try:
             records = get_useraccess(db)
-            return list_to_schema(UserAccessInDB, records)
+            result = []
+            for r in records:
+                data = {
+                    'UserID': r.UserID,
+                    'CompanyID': r.CompanyID,
+                    'BranchID': r.BranchID,
+                    'RoleID': r.RoleID,
+                    'UserName': getattr(r.users_, 'FullName', None),
+                    'CompanyName': getattr(r.companyData_, 'Name', None),
+                    'BranchName': getattr(r.branches_, 'Name', None),
+                    'RoleName': getattr(r.roles_, 'RoleName', None),
+                }
+                result.append(UserAccessInDB(**data))
+            return result
         finally:
             db_gen.close()
 
@@ -27,7 +40,19 @@ class UseraccessQuery:
         try:
             record = get_useraccess_by_id(
                 db, userID, companyID, branchID, roleID)
-            return obj_to_schema(UserAccessInDB, record) if record else None
+            if record:
+                data = {
+                    'UserID': record.UserID,
+                    'CompanyID': record.CompanyID,
+                    'BranchID': record.BranchID,
+                    'RoleID': record.RoleID,
+                    'UserName': getattr(record.users_, 'FullName', None),
+                    'CompanyName': getattr(record.companyData_, 'Name', None),
+                    'BranchName': getattr(record.branches_, 'Name', None),
+                    'RoleName': getattr(record.roles_, 'RoleName', None),
+                }
+                return UserAccessInDB(**data)
+            return None
         finally:
             db_gen.close()
 

--- a/app/graphql/schemas/useraccess.py
+++ b/app/graphql/schemas/useraccess.py
@@ -25,3 +25,7 @@ class UserAccessInDB:
     CompanyID: int
     BranchID: int
     RoleID: int
+    UserName: str | None = None
+    CompanyName: str | None = None
+    BranchName: str | None = None
+    RoleName: str | None = None

--- a/frontend/src/pages/RolesUsers.jsx
+++ b/frontend/src/pages/RolesUsers.jsx
@@ -118,7 +118,7 @@ export default function RolesUsers() {
                     {records.map((r, idx) => (
                         <li key={idx} className="border p-2 rounded flex justify-between items-center">
                             <span>
-                                Usuario: {r.UserID} - Compañía: {r.CompanyID} - Sucursal: {r.BranchID} - Rol: {r.RoleID}
+                                Usuario: {r.UserName || r.UserID} - Compañía: {r.CompanyName || r.CompanyID} - Sucursal: {r.BranchName || r.BranchID} - Rol: {r.RoleName || r.RoleID}
                             </span>
                             <span className="space-x-2">
                                 <button onClick={() => handleEdit(r)} className="px-2 py-1 text-sm bg-gray-100 rounded hover:bg-gray-200">Editar</button>

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -209,9 +209,13 @@ export const QUERIES = {
         query GetAllUseraccess {
             allUseraccess {
                 UserID
+                UserName
                 CompanyID
+                CompanyName
                 BranchID
+                BranchName
                 RoleID
+                RoleName
             }
         }
     `,
@@ -220,9 +224,13 @@ export const QUERIES = {
         query GetUseraccessById($userID: Int!, $companyID: Int!, $branchID: Int!, $roleID: Int!) {
             useraccessById(userID: $userID, companyID: $companyID, branchID: $branchID, roleID: $roleID) {
                 UserID
+                UserName
                 CompanyID
+                CompanyName
                 BranchID
+                BranchName
                 RoleID
+                RoleName
             }
         }
     `,


### PR DESCRIPTION
## Summary
- incluir campos de nombres en esquema `UserAccessInDB`
- mapear relaciones para obtener nombres en el resolver de `useraccess`
- pedir campos de nombres desde el frontend
- mostrar esos nombres en la lista de Roles y Usuarios

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870987a53c08323b063e570bb9ddba2