### PR TITLE
Add company and branch management

### DIFF
--- a/app/graphql/mutations/branches.py
+++ b/app/graphql/mutations/branches.py
@@ -1,0 +1,40 @@
+# app/graphql/mutations/branches.py
+import strawberry
+from typing import Optional
+from app.graphql.schemas.branches import BranchesCreate, BranchesUpdate, BranchesInDB
+from app.graphql.crud.branches import create_branches, update_branches, delete_branches
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+@strawberry.type
+class BranchesMutations:
+    @strawberry.mutation
+    def create_branch(self, info: Info, data: BranchesCreate) -> BranchesInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            obj = create_branches(db, data)
+            return obj_to_schema(BranchesInDB, obj)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_branch(self, info: Info, branchID: int, data: BranchesUpdate) -> Optional[BranchesInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated = update_branches(db, branchID, data)
+            return obj_to_schema(BranchesInDB, updated) if updated else None
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_branch(self, info: Info, branchID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_branches(db, branchID)
+            return deleted is not None
+        finally:
+            db_gen.close()

--- a/app/graphql/mutations/companydata.py
+++ b/app/graphql/mutations/companydata.py
@@ -1,0 +1,40 @@
+# app/graphql/mutations/companydata.py
+import strawberry
+from typing import Optional
+from app.graphql.schemas.companydata import CompanyDataCreate, CompanyDataUpdate, CompanyDataInDB
+from app.graphql.crud.companydata import create_companydata, update_companydata, delete_companydata
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+@strawberry.type
+class CompanydataMutations:
+    @strawberry.mutation
+    def create_company(self, info: Info, data: CompanyDataCreate) -> CompanyDataInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            obj = create_companydata(db, data)
+            return obj_to_schema(CompanyDataInDB, obj)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_company(self, info: Info, companyID: int, data: CompanyDataUpdate) -> Optional[CompanyDataInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated = update_companydata(db, companyID, data)
+            return obj_to_schema(CompanyDataInDB, updated) if updated else None
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_company(self, info: Info, companyID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_companydata(db, companyID)
+            return deleted is not None
+        finally:
+            db_gen.close()

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -61,6 +61,8 @@ from app.graphql.mutations.creditcardgroups import CreditCardGroupsMutations
 from app.graphql.mutations.creditcards import CreditCardsMutations
 from app.graphql.mutations.carmodels import CarModelsMutations
 from app.graphql.mutations.cars import CarsMutations
+from app.graphql.mutations.branches import BranchesMutations
+from app.graphql.mutations.companydata import CompanydataMutations
 from app.graphql.mutations.warehouses import WarehousesMutations
 from app.graphql.mutations.pricelists import PricelistsMutations
 from app.graphql.mutations.orders import OrdersMutations
@@ -404,6 +406,8 @@ class Mutation(
     SaleConditionsMutations,
     CreditCardGroupsMutations,
     CreditCardsMutations,
+    BranchesMutations,
+    CompanydataMutations,
     WarehousesMutations,
     PricelistsMutations,
     OrdersMutations,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,8 @@ import Brands from "./pages/Brands";
 import CarBrands from "./pages/CarBrands";
 import CarModels from "./pages/CarModels";
 import Cars from "./pages/Cars";
+import Branches from "./pages/Branches";
+import CompanyData from "./pages/CompanyData";
 import ItemCategories from "./pages/ItemCategories";
 import ItemSubcategories from "./pages/ItemSubcategories";
 import Items from "./pages/Items";
@@ -204,6 +206,8 @@ export default function App() {
                     <Route path="items" element={<Items />} />
                     <Route path="pricelists" element={<PriceLists />} />
                     <Route path="warehouses" element={<Warehouses />} />
+                    <Route path="branches" element={<Branches />} />
+                    <Route path="companydata" element={<CompanyData />} />
                     <Route path="carbrands" element={<CarBrands />} />
                     <Route path="carmodels" element={<CarModels />} />
                     <Route path="cars" element={<Cars />} />

--- a/frontend/src/pages/BranchCreate.jsx
+++ b/frontend/src/pages/BranchCreate.jsx
@@ -1,0 +1,133 @@
+// frontend/src/pages/BranchCreate.jsx
+import { useState, useEffect } from "react";
+import { branchOperations, companyOperations } from "../utils/graphqlClient";
+
+export default function BranchCreate({ onClose, onSave, branch: initialBranch = null }) {
+    const [companies, setCompanies] = useState([]);
+    const [companyID, setCompanyID] = useState("");
+    const [name, setName] = useState("");
+    const [address, setAddress] = useState("");
+    const [phone, setPhone] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [isEdit, setIsEdit] = useState(false);
+
+    useEffect(() => {
+        const loadCompanies = async () => {
+            try {
+                const res = await companyOperations.getAllCompanies();
+                setCompanies(res);
+            } catch (err) {
+                console.error("Error cargando compañías:", err);
+            }
+        };
+        loadCompanies();
+    }, []);
+
+    useEffect(() => {
+        if (initialBranch) {
+            setIsEdit(true);
+            setCompanyID(initialBranch.CompanyID || "");
+            setName(initialBranch.Name || "");
+            setAddress(initialBranch.Address || "");
+            setPhone(initialBranch.Phone || "");
+        }
+    }, [initialBranch]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            const payload = {
+                CompanyID: parseInt(companyID),
+                Name: name,
+                Address: address,
+                Phone: phone,
+            };
+            let result;
+            if (isEdit) {
+                result = await branchOperations.updateBranch(initialBranch.BranchID, payload);
+            } else {
+                result = await branchOperations.createBranch(payload);
+            }
+            onSave && onSave(result);
+            onClose && onClose();
+        } catch (err) {
+            console.error("Error guardando sucursal:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Sucursal' : 'Nueva Sucursal'}</h2>
+            {error && <div className="text-red-600 mb-2">{error}</div>}
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-1">Compañía</label>
+                    <select
+                        value={companyID}
+                        onChange={(e) => setCompanyID(e.target.value)}
+                        className="w-full border p-2 rounded"
+                        required
+                    >
+                        <option value="">Seleccione</option>
+                        {companies.map((c) => (
+                            <option key={c.CompanyID} value={c.CompanyID}>
+                                {c.Name}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Nombre</label>
+                    <input
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        className="w-full border p-2 rounded"
+                        required
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Dirección</label>
+                    <input
+                        type="text"
+                        value={address}
+                        onChange={(e) => setAddress(e.target.value)}
+                        className="w-full border p-2 rounded"
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Teléfono</label>
+                    <input
+                        type="text"
+                        value={phone}
+                        onChange={(e) => setPhone(e.target.value)}
+                        className="w-full border p-2 rounded"
+                    />
+                </div>
+                <div className="flex justify-end space-x-4 pt-4 border-t">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        disabled={loading}
+                        className="px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+                    >
+                        Cancelar
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={loading || !companyID || !name.trim()}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                        {loading ? 'Guardando...' : 'Guardar'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/pages/Branches.jsx
+++ b/frontend/src/pages/Branches.jsx
@@ -1,0 +1,128 @@
+// frontend/src/pages/Branches.jsx
+import { useEffect, useState } from "react";
+import { branchOperations } from "../utils/graphqlClient";
+import BranchCreate from "./BranchCreate";
+import TableFilters from "../components/TableFilters";
+import { openReactWindow } from "../utils/openReactWindow";
+
+export default function Branches() {
+    const [allBranches, setAllBranches] = useState([]);
+    const [branches, setBranches] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
+
+    useEffect(() => { loadBranches(); }, []);
+
+    const loadBranches = async () => {
+        try {
+            setLoading(true);
+            const data = await branchOperations.getAllBranches();
+            setAllBranches(data);
+            setBranches(data);
+        } catch (err) {
+            console.error("Error cargando sucursales:", err);
+            setError(err.message);
+            setBranches([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-branches') {
+                loadBranches();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
+    }, []);
+
+    const handleCreate = () => {
+        openReactWindow(
+            (popup) => (
+                <BranchCreate
+                    onSave={() => {
+                        popup.opener.postMessage('reload-branches', '*');
+                        popup.close();
+                    }}
+                    onClose={() => popup.close()}
+                />
+            ),
+            'Nueva Sucursal'
+        );
+    };
+
+    const handleFilterChange = (filtered) => setBranches(filtered);
+
+    const handleEdit = (br) => {
+        openReactWindow(
+            (popup) => (
+                <BranchCreate
+                    branch={br}
+                    onSave={() => {
+                        popup.opener.postMessage('reload-branches', '*');
+                        popup.close();
+                    }}
+                    onClose={() => popup.close()}
+                />
+            ),
+            'Editar Sucursal'
+        );
+    };
+
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar sucursal?')) return;
+        try {
+            await branchOperations.deleteBranch(id);
+            loadBranches();
+        } catch (err) {
+            alert('Error al borrar sucursal: ' + err.message);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold text-gray-800">Sucursales</h1>
+                <div className="flex space-x-2">
+                    <button
+                        onClick={() => setShowFilters(!showFilters)}
+                        className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700"
+                    >
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button onClick={loadBranches} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                        Recargar
+                    </button>
+                    <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                        Nueva Sucursal
+                    </button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters modelName="branches" data={allBranches} onFilterChange={handleFilterChange} />
+                </div>
+            )}
+            {error && <div className="text-red-600 mb-4">{error}</div>}
+            {loading ? (
+                <div>Cargando...</div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {branches.map((br) => (
+                        <div key={br.BranchID} className="bg-white rounded shadow p-4">
+                            <h3 className="text-lg font-semibold mb-2">{br.Name}</h3>
+                            <p className="text-sm mb-2">Empresa ID: {br.CompanyID}</p>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(br)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(br.BranchID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/pages/CompanyCreate.jsx
+++ b/frontend/src/pages/CompanyCreate.jsx
@@ -1,0 +1,70 @@
+// frontend/src/pages/CompanyCreate.jsx
+import { useState, useEffect } from "react";
+import { companyOperations } from "../utils/graphqlClient";
+
+export default function CompanyCreate({ onClose, onSave, company: initialCompany = null }) {
+    const [name, setName] = useState("");
+    const [address, setAddress] = useState("");
+    const [cuit, setCuit] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [isEdit, setIsEdit] = useState(false);
+
+    useEffect(() => {
+        if (initialCompany) {
+            setIsEdit(true);
+            setName(initialCompany.Name || "");
+            setAddress(initialCompany.Address || "");
+            setCuit(initialCompany.CUIT || "");
+        }
+    }, [initialCompany]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            const payload = { Name: name, Address: address, CUIT: cuit };
+            let result;
+            if (isEdit) {
+                result = await companyOperations.updateCompany(initialCompany.CompanyID, payload);
+            } else {
+                result = await companyOperations.createCompany(payload);
+            }
+            onSave && onSave(result);
+            onClose && onClose();
+        } catch (err) {
+            console.error("Error guardando compañía:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Empresa' : 'Nueva Empresa'}</h2>
+            {error && <div className="text-red-600 mb-2">{error}</div>}
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-1">Nombre</label>
+                    <input type="text" value={name} onChange={(e) => setName(e.target.value)} className="w-full border p-2 rounded" required />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Dirección</label>
+                    <input type="text" value={address} onChange={(e) => setAddress(e.target.value)} className="w-full border p-2 rounded" />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">CUIT</label>
+                    <input type="text" value={cuit} onChange={(e) => setCuit(e.target.value)} className="w-full border p-2 rounded" />
+                </div>
+                <div className="flex justify-end space-x-4 pt-4 border-t">
+                    <button type="button" onClick={onClose} disabled={loading} className="px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50">Cancelar</button>
+                    <button type="submit" disabled={loading || !name.trim()} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+                        {loading ? 'Guardando...' : 'Guardar'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/pages/CompanyData.jsx
+++ b/frontend/src/pages/CompanyData.jsx
@@ -1,0 +1,128 @@
+// frontend/src/pages/CompanyData.jsx
+import { useEffect, useState } from "react";
+import { companyOperations } from "../utils/graphqlClient";
+import CompanyCreate from "./CompanyCreate";
+import TableFilters from "../components/TableFilters";
+import { openReactWindow } from "../utils/openReactWindow";
+
+export default function CompanyData() {
+    const [allCompanies, setAllCompanies] = useState([]);
+    const [companies, setCompanies] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
+
+    useEffect(() => { loadCompanies(); }, []);
+
+    const loadCompanies = async () => {
+        try {
+            setLoading(true);
+            const data = await companyOperations.getAllCompanies();
+            setAllCompanies(data);
+            setCompanies(data);
+        } catch (err) {
+            console.error("Error cargando compañías:", err);
+            setError(err.message);
+            setCompanies([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-companies') {
+                loadCompanies();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
+    }, []);
+
+    const handleCreate = () => {
+        openReactWindow(
+            (popup) => (
+                <CompanyCreate
+                    onSave={() => {
+                        popup.opener.postMessage('reload-companies', '*');
+                        popup.close();
+                    }}
+                    onClose={() => popup.close()}
+                />
+            ),
+            'Nueva Empresa'
+        );
+    };
+
+    const handleFilterChange = (filtered) => setCompanies(filtered);
+
+    const handleEdit = (c) => {
+        openReactWindow(
+            (popup) => (
+                <CompanyCreate
+                    company={c}
+                    onSave={() => {
+                        popup.opener.postMessage('reload-companies', '*');
+                        popup.close();
+                    }}
+                    onClose={() => popup.close()}
+                />
+            ),
+            'Editar Empresa'
+        );
+    };
+
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar empresa?')) return;
+        try {
+            await companyOperations.deleteCompany(id);
+            loadCompanies();
+        } catch (err) {
+            alert('Error al borrar empresa: ' + err.message);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold text-gray-800">Empresas</h1>
+                <div className="flex space-x-2">
+                    <button
+                        onClick={() => setShowFilters(!showFilters)}
+                        className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700"
+                    >
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button onClick={loadCompanies} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                        Recargar
+                    </button>
+                    <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                        Nueva Empresa
+                    </button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters modelName="companydata" data={allCompanies} onFilterChange={handleFilterChange} />
+                </div>
+            )}
+            {error && <div className="text-red-600 mb-4">{error}</div>}
+            {loading ? (
+                <div>Cargando...</div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {companies.map((c) => (
+                        <div key={c.CompanyID} className="bg-white rounded shadow p-4">
+                            <h3 className="text-lg font-semibold mb-2">{c.Name}</h3>
+                            <p className="text-sm mb-2">{c.Address}</p>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(c)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(c.CompanyID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -475,6 +475,56 @@ export const MUTATIONS = {
         }
     `,
 
+    // EMPRESAS
+    CREATE_COMPANY: `
+        mutation CreateCompany($input: CompanyDataCreate!) {
+            createCompany(data: $input) {
+                CompanyID
+                Name
+                Address
+            }
+        }
+    `,
+    UPDATE_COMPANY: `
+        mutation UpdateCompany($companyID: Int!, $input: CompanyDataUpdate!) {
+            updateCompany(companyID: $companyID, data: $input) {
+                CompanyID
+                Name
+                Address
+            }
+        }
+    `,
+    DELETE_COMPANY: `
+        mutation DeleteCompany($companyID: Int!) {
+            deleteCompany(companyID: $companyID)
+        }
+    `,
+
+    // SUCURSALES
+    CREATE_BRANCH: `
+        mutation CreateBranch($input: BranchesCreate!) {
+            createBranch(data: $input) {
+                BranchID
+                CompanyID
+                Name
+            }
+        }
+    `,
+    UPDATE_BRANCH: `
+        mutation UpdateBranch($branchID: Int!, $input: BranchesUpdate!) {
+            updateBranch(branchID: $branchID, data: $input) {
+                BranchID
+                CompanyID
+                Name
+            }
+        }
+    `,
+    DELETE_BRANCH: `
+        mutation DeleteBranch($branchID: Int!) {
+            deleteBranch(branchID: $branchID)
+        }
+    `,
+
     // ======= ORDENES - NUEVAS MUTACIONES CORREGIDAS =======
     CREATE_ORDER: `
         mutation CreateOrder($input: OrdersCreate!) {

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1230,10 +1230,50 @@ export const orderOperations = {
 export const companyOperations = {
     async getAllCompanies() {
         try {
-            const data = await graphqlClient.query(`query { allCompanydata { CompanyID Name } }`);
+            const data = await graphqlClient.query(QUERIES.GET_ALL_COMPANIES);
             return data.allCompanydata || [];
         } catch (error) {
             console.error("Error obteniendo compañías:", error);
+            throw error;
+        }
+    },
+
+    async getCompanyById(id) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_COMPANY_BY_ID, { id });
+            return data.companydataById;
+        } catch (error) {
+            console.error("Error obteniendo compañía:", error);
+            throw error;
+        }
+    },
+
+    async createCompany(dataInput) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.CREATE_COMPANY, { input: dataInput });
+            return data.createCompany;
+        } catch (error) {
+            console.error("Error creando compañía:", error);
+            throw error;
+        }
+    },
+
+    async updateCompany(id, dataInput) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_COMPANY, { companyID: id, input: dataInput });
+            return data.updateCompany;
+        } catch (error) {
+            console.error("Error actualizando compañía:", error);
+            throw error;
+        }
+    },
+
+    async deleteCompany(id) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.DELETE_COMPANY, { companyID: id });
+            return data.deleteCompany;
+        } catch (error) {
+            console.error("Error eliminando compañía:", error);
             throw error;
         }
     }
@@ -1242,10 +1282,20 @@ export const companyOperations = {
 export const branchOperations = {
     async getAllBranches() {
         try {
-            const data = await graphqlClient.query(`query { allBranches { BranchID Name CompanyID } }`);
+            const data = await graphqlClient.query(QUERIES.GET_ALL_BRANCHES);
             return data.allBranches || [];
         } catch (error) {
             console.error("Error obteniendo sucursales:", error);
+            throw error;
+        }
+    },
+
+    async getBranchById(id) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_BRANCH_BY_ID, { id });
+            return data.branchesById;
+        } catch (error) {
+            console.error("Error obteniendo sucursal:", error);
             throw error;
         }
     },
@@ -1256,6 +1306,36 @@ export const branchOperations = {
             return data.branchesByCompany || [];
         } catch (error) {
             console.error("Error obteniendo sucursales por compañía:", error);
+            throw error;
+        }
+    },
+
+    async createBranch(dataInput) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.CREATE_BRANCH, { input: dataInput });
+            return data.createBranch;
+        } catch (error) {
+            console.error("Error creando sucursal:", error);
+            throw error;
+        }
+    },
+
+    async updateBranch(id, dataInput) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_BRANCH, { branchID: id, input: dataInput });
+            return data.updateBranch;
+        } catch (error) {
+            console.error("Error actualizando sucursal:", error);
+            throw error;
+        }
+    },
+
+    async deleteBranch(id) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.DELETE_BRANCH, { branchID: id });
+            return data.deleteBranch;
+        } catch (error) {
+            console.error("Error eliminando sucursal:", error);
             throw error;
         }
     }

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -749,6 +749,51 @@ export const QUERIES = {
         }
     `,
 
+    // EMPRESAS
+    GET_ALL_COMPANIES: `
+        query GetAllCompanies {
+            allCompanydata {
+                CompanyID
+                Name
+                Address
+            }
+        }
+    `,
+    GET_COMPANY_BY_ID: `
+        query GetCompanyById($id: Int!) {
+            companydataById(id: $id) {
+                CompanyID
+                Name
+                Address
+                CUIT
+            }
+        }
+    `,
+
+    // SUCURSALES
+    GET_ALL_BRANCHES: `
+        query GetAllBranches {
+            allBranches {
+                BranchID
+                CompanyID
+                Name
+                Address
+                Phone
+            }
+        }
+    `,
+    GET_BRANCH_BY_ID: `
+        query GetBranchById($id: Int!) {
+            branchesById(id: $id) {
+                BranchID
+                CompanyID
+                Name
+                Address
+                Phone
+            }
+        }
+    `,
+
     // BÚSQUEDA DE CLIENTES
     SEARCH_CLIENTS: `
         query SearchClients($searchTerm: String!, $isActive: Boolean) {


### PR DESCRIPTION
## Summary
- add GraphQL mutations for branches and companies
- expose new mutations in schema
- support create/update/delete for companies and branches in operations
- include queries for companies and branches
- add React pages to list and create companies or branches with filters
- hook new routes into app

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68709e40323c8323a5167427136adfb2