### PR TITLE
Enable full company data fields with logo upload

### DIFF
--- a/frontend/src/pages/CompanyCreate.jsx
+++ b/frontend/src/pages/CompanyCreate.jsx
@@ -6,6 +6,10 @@ export default function CompanyCreate({ onClose, onSave, company: initialCompany
     const [name, setName] = useState("");
     const [address, setAddress] = useState("");
     const [cuit, setCuit] = useState("");
+    const [grossIncome, setGrossIncome] = useState("");
+    const [startDate, setStartDate] = useState("");
+    const [logo, setLogo] = useState("");
+    const [logoPreview, setLogoPreview] = useState("");
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
     const [isEdit, setIsEdit] = useState(false);
@@ -16,6 +20,10 @@ export default function CompanyCreate({ onClose, onSave, company: initialCompany
             setName(initialCompany.Name || "");
             setAddress(initialCompany.Address || "");
             setCuit(initialCompany.CUIT || "");
+            setGrossIncome(initialCompany.Grossincome || "");
+            setStartDate(initialCompany.Startdate ? initialCompany.Startdate.slice(0, 10) : "");
+            setLogo(initialCompany.Logo || "");
+            setLogoPreview(initialCompany.Logo ? `data:image/*;base64,${initialCompany.Logo}` : "");
         }
     }, [initialCompany]);
 
@@ -24,7 +32,14 @@ export default function CompanyCreate({ onClose, onSave, company: initialCompany
         setLoading(true);
         setError(null);
         try {
-            const payload = { Name: name, Address: address, CUIT: cuit };
+            const payload = {
+                Name: name,
+                Address: address,
+                CUIT: cuit,
+                Grossincome: grossIncome || null,
+                Startdate: startDate ? new Date(startDate).toISOString() : null,
+                Logo: logo || null,
+            };
             let result;
             if (isEdit) {
                 result = await companyOperations.updateCompany(initialCompany.CompanyID, payload);
@@ -57,6 +72,39 @@ export default function CompanyCreate({ onClose, onSave, company: initialCompany
                 <div>
                     <label className="block text-sm font-medium mb-1">CUIT</label>
                     <input type="text" value={cuit} onChange={(e) => setCuit(e.target.value)} className="w-full border p-2 rounded" />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Ingresos brutos</label>
+                    <input type="text" value={grossIncome} onChange={(e) => setGrossIncome(e.target.value)} className="w-full border p-2 rounded" />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Fecha de inicio</label>
+                    <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} className="w-full border p-2 rounded" />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Logo</label>
+                    <input
+                        type="file"
+                        accept="image/*"
+                        onChange={(e) => {
+                            const file = e.target.files?.[0];
+                            if (!file) return;
+                            const reader = new FileReader();
+                            reader.onload = (ev) => {
+                                const result = ev.target?.result;
+                                if (typeof result === "string") {
+                                    const base64 = result.split(",")[1] || result;
+                                    setLogo(base64);
+                                    setLogoPreview(result);
+                                }
+                            };
+                            reader.readAsDataURL(file);
+                        }}
+                        className="w-full border p-2 rounded"
+                    />
+                    {logoPreview && (
+                        <img src={logoPreview} alt="Logo" className="mt-2 h-20 object-contain" />
+                    )}
                 </div>
                 <div className="flex justify-end space-x-4 pt-4 border-t">
                     <button type="button" onClick={onClose} disabled={loading} className="px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50">Cancelar</button>

--- a/frontend/src/pages/CompanyData.jsx
+++ b/frontend/src/pages/CompanyData.jsx
@@ -113,11 +113,21 @@ export default function CompanyData() {
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                     {companies.map((c) => (
                         <div key={c.CompanyID} className="bg-white rounded shadow p-4">
-                            <h3 className="text-lg font-semibold mb-2">{c.Name}</h3>
-                            <p className="text-sm mb-2">{c.Address}</p>
-                            <div className="flex space-x-2">
-                                <button onClick={() => handleEdit(c)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
-                                <button onClick={() => handleDelete(c.CompanyID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            {c.Logo && (
+                                <img
+                                    src={`data:image/*;base64,${c.Logo}`}
+                                    alt="Logo"
+                                    className="h-16 mb-2 object-contain"
+                                />
+                            )}
+                            <h3 className="text-lg font-semibold mb-1">{c.Name}</h3>
+                            <p className="text-sm mb-1">{c.Address}</p>
+                            {c.CUIT && <p className="text-sm mb-1">CUIT: {c.CUIT}</p>}
+                            {c.Grossincome && <p className="text-sm mb-1">Ingresos brutos: {c.Grossincome}</p>}
+                            {c.Startdate && <p className="text-sm mb-1">Inicio: {c.Startdate.slice(0, 10)}</p>}
+                            <div className="flex space-x-2 mt-2">
+                                <button onClick={() => handleEdit(c)} className="px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(c.CompanyID)} className="px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
                             </div>
                         </div>
                     ))}

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -482,6 +482,10 @@ export const MUTATIONS = {
                 CompanyID
                 Name
                 Address
+                CUIT
+                Grossincome
+                Startdate
+                Logo
             }
         }
     `,
@@ -491,6 +495,10 @@ export const MUTATIONS = {
                 CompanyID
                 Name
                 Address
+                CUIT
+                Grossincome
+                Startdate
+                Logo
             }
         }
     `,

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -756,6 +756,10 @@ export const QUERIES = {
                 CompanyID
                 Name
                 Address
+                CUIT
+                Grossincome
+                Startdate
+                Logo
             }
         }
     `,
@@ -766,6 +770,9 @@ export const QUERIES = {
                 Name
                 Address
                 CUIT
+                Grossincome
+                Startdate
+                Logo
             }
         }
     `,


### PR DESCRIPTION
## Summary
- decode base64 when saving company logo
- include CUIT, Grossincome, Startdate and Logo in company queries and mutations
- extend company creation form with GrossIncome, StartDate and logo upload (with preview)
- show company details and logo in list view

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6870a5958f7c8323a9248431a14dbf2c