### PR TITLE
Implement temp order detail mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,12 @@ El proyecto también incluye:
 - `deploy.py`: Script original solo para backend
 - `Git-PushToBranch.ps1`: Script PowerShell para Git
 - `Kill-Port8000.ps1`: Script para liberar el puerto 8000
+
+## Gestión temporal de ítems en órdenes
+
+Durante la creación o edición de una orden, los ítems se almacenan en la tabla
+`TempOrderDetails`. Esto permite modificarlos libremente desde el frontend sin
+afectar la orden real. Cuando se confirma la operación, se debe invocar la
+mutación `finalizeOrder` enviando el `orderID` y el `sessionID`; dicha acción
+mueve los registros temporales a `OrderDetails` y aplica los cambios de forma
+permanente.

--- a/app/graphql/crud/temporderdetails.py
+++ b/app/graphql/crud/temporderdetails.py
@@ -14,12 +14,12 @@ def get_temporderdetails(db: Session) -> List[TempOrderDetails]:
     return db.query(TempOrderDetails).all()
 
 
-def get_temporderdetails_by_id(
-    db: Session, temporderitemid: int
+def get_temporderdetail_by_session(
+    db: Session, session_id: str
 ) -> Optional[TempOrderDetails]:
     return (
         db.query(TempOrderDetails)
-        .filter(TempOrderDetails.tempOrderItemID == temporderitemid)
+        .filter(TempOrderDetails.OrderSessionID == session_id)
         .first()
     )
 
@@ -27,7 +27,8 @@ def get_temporderdetails_by_id(
 def create_temporderdetails(
     db: Session, data: TempOrderDetailsCreate
 ) -> TempOrderDetails:
-    obj = TempOrderDetails(**asdict(data))
+    data_dict = {k: v for k, v in asdict(data).items() if v is not None}
+    obj = TempOrderDetails(**data_dict)
     db.add(obj)
     db.commit()
     db.refresh(obj)
@@ -35,9 +36,9 @@ def create_temporderdetails(
 
 
 def update_temporderdetails(
-    db: Session, temporderitemid: int, data: TempOrderDetailsUpdate
+    db: Session, session_id: str, data: TempOrderDetailsUpdate
 ) -> Optional[TempOrderDetails]:
-    obj = get_temporderdetails_by_id(db, temporderitemid)
+    obj = get_temporderdetail_by_session(db, session_id)
     if not obj:
         return None
     for field, value in asdict(data).items():
@@ -49,9 +50,9 @@ def update_temporderdetails(
 
 
 def delete_temporderdetails(
-    db: Session, temporderitemid: int
+    db: Session, session_id: str
 ) -> Optional[TempOrderDetails]:
-    obj = get_temporderdetails_by_id(db, temporderitemid)
+    obj = get_temporderdetail_by_session(db, session_id)
     if not obj:
         return None
     db.delete(obj)
@@ -64,6 +65,6 @@ def get_temporderdetails_by_session(
 ) -> List[TempOrderDetails]:
     return (
         db.query(TempOrderDetails)
-        .filter(TempOrderDetails.orderSessionID == session_id)
+        .filter(TempOrderDetails.OrderSessionID == session_id)
         .all()
     )

--- a/app/graphql/mutations/temporderdetails.py
+++ b/app/graphql/mutations/temporderdetails.py
@@ -1,0 +1,55 @@
+# app/graphql/mutations/temporderdetails.py
+import strawberry
+from typing import Optional
+from app.graphql.schemas.temporderdetails import (
+    TempOrderDetailsCreate,
+    TempOrderDetailsUpdate,
+    TempOrderDetailsInDB,
+)
+from app.graphql.crud.temporderdetails import (
+    create_temporderdetails,
+    update_temporderdetails,
+    delete_temporderdetails,
+)
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+
+@strawberry.type
+class TempOrderDetailsMutations:
+    @strawberry.mutation
+    def create_temporderdetail(
+        self, info: Info, data: TempOrderDetailsCreate
+    ) -> TempOrderDetailsInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            obj = create_temporderdetails(db, data)
+            return obj_to_schema(TempOrderDetailsInDB, obj)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_temporderdetail(
+        self, info: Info, sessionID: str, data: TempOrderDetailsUpdate
+    ) -> Optional[TempOrderDetailsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated = update_temporderdetails(db, sessionID, data)
+            return (
+                obj_to_schema(TempOrderDetailsInDB, updated) if updated else None
+            )
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_temporderdetail(self, info: Info, sessionID: str) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_temporderdetails(db, sessionID)
+            return deleted is not None
+        finally:
+            db_gen.close()

--- a/app/graphql/resolvers/temporderdetails.py
+++ b/app/graphql/resolvers/temporderdetails.py
@@ -21,12 +21,29 @@ class TemporderdetailsQuery:
             db_gen.close()
 
     @strawberry.field
-    def temporderdetails_by_id(self, info: Info, id: int) -> Optional[TempOrderDetailsInDB]:
+    def temporderdetails_by_session(
+        self, info: Info, sessionID: str
+    ) -> List[TempOrderDetailsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            items = db.query(TempOrderDetails).filter(
+                TempOrderDetails.OrderSessionID == sessionID
+            ).all()
+            return list_to_schema(TempOrderDetailsInDB, items)
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def temporderdetail_by_session(
+        self, info: Info, sessionID: str
+    ) -> Optional[TempOrderDetailsInDB]:
         db_gen = get_db()
         db = next(db_gen)
         try:
             item = db.query(TempOrderDetails).filter(
-                TempOrderDetails.tempOrderItemID == id).first()
+                TempOrderDetails.OrderSessionID == sessionID
+            ).first()
             return obj_to_schema(TempOrderDetailsInDB, item) if item else None
         finally:
             db_gen.close()

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -65,6 +65,7 @@ from app.graphql.mutations.branches import BranchesMutations
 from app.graphql.mutations.companydata import CompanydataMutations
 from app.graphql.mutations.warehouses import WarehousesMutations
 from app.graphql.mutations.pricelists import PricelistsMutations
+from app.graphql.mutations.temporderdetails import TempOrderDetailsMutations
 from app.graphql.mutations.orders import OrdersMutations
 from app.graphql.mutations.servicetype import ServiceTypeMutations
 from app.graphql.mutations.documenttypes import DocumentTypesMutations
@@ -410,6 +411,7 @@ class Mutation(
     CompanydataMutations,
     WarehousesMutations,
     PricelistsMutations,
+    TempOrderDetailsMutations,
     OrdersMutations,
     ServiceTypeMutations,
     DocumentTypesMutations,

--- a/app/graphql/schemas/temporderdetails.py
+++ b/app/graphql/schemas/temporderdetails.py
@@ -5,7 +5,9 @@ from uuid import UUID
 
 @strawberry.input
 class TempOrderDetailsCreate:
-    OrderSessionID: UUID
+    OrderDetailID: Optional[int] = None
+    OrderID: Optional[int] = None
+    OrderSessionID: Optional[UUID] = None
     CompanyID: int
     BranchID: int
     UserID: int
@@ -18,6 +20,8 @@ class TempOrderDetailsCreate:
 
 @strawberry.input
 class TempOrderDetailsUpdate:
+    OrderDetailID: Optional[int] = None
+    OrderID: Optional[int] = None
     OrderSessionID: Optional[UUID] = None
     CompanyID: Optional[int] = None
     BranchID: Optional[int] = None
@@ -32,6 +36,8 @@ class TempOrderDetailsUpdate:
 @strawberry.type
 class TempOrderDetailsInDB:
     TempOrderItemID: int
+    OrderDetailID: Optional[int]
+    OrderID: Optional[int]
     OrderSessionID: UUID
     CompanyID: int
     BranchID: int


### PR DESCRIPTION
## Summary
- allow temporary order details to be created, updated and deleted
- fetch temporary order details by session
- include TempOrderDetails mutations in GraphQL schema
- make OrderSessionID optional when creating temporary details
- adjust temp order detail CRUD to use OrderSessionID as the unique key

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6870c0464e888323a3bbb35b8cb26129