### PR TITLE
Fix temp order session creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,6 @@ afectar la orden real. Cuando se confirma la operación, se debe invocar la
 mutación `finalizeOrder` enviando el `orderID` y el `sessionID`; dicha acción
 mueve los registros temporales a `OrderDetails` y aplica los cambios de forma
 permanente.
+Si al crear un ítem no enviás un `sessionID`, el backend generará uno
+automáticamente y lo devolverá en la respuesta. Utilizá ese mismo `sessionID`
+para los ítems siguientes y para la mutación `finalizeOrder`.

--- a/app/graphql/crud/temporderdetails.py
+++ b/app/graphql/crud/temporderdetails.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from typing import List, Optional
 from dataclasses import asdict
 
+from uuid import uuid4
 from app.models.temporderdetails import TempOrderDetails
 from app.graphql.schemas.temporderdetails import (
     TempOrderDetailsCreate,
@@ -28,6 +29,8 @@ def create_temporderdetails(
     db: Session, data: TempOrderDetailsCreate
 ) -> TempOrderDetails:
     data_dict = {k: v for k, v in asdict(data).items() if v is not None}
+    if "OrderSessionID" not in data_dict:
+        data_dict["OrderSessionID"] = uuid4()
     obj = TempOrderDetails(**data_dict)
     db.add(obj)
     db.commit()
@@ -49,9 +52,7 @@ def update_temporderdetails(
     return obj
 
 
-def delete_temporderdetails(
-    db: Session, session_id: str
-) -> Optional[TempOrderDetails]:
+def delete_temporderdetails(db: Session, session_id: str) -> Optional[TempOrderDetails]:
     obj = get_temporderdetail_by_session(db, session_id)
     if not obj:
         return None


### PR DESCRIPTION
## Summary
- handle missing session IDs when creating temp order details
- clarify session ID usage in readme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68723692a2d88323bb7fb4290284ed23