### PR TITLE
Fix session item update by temp item ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,7 @@ para los ítems siguientes y para la mutación `finalizeOrder`.
 Cuando se crea una orden enviando una lista de ítems, dichos registros también
 se almacenan en `TempOrderDetails` con un `sessionID` único hasta su
 confirmación definitiva.
+
+Para modificar un ítem temporal utilizá la mutación `update_temporderdetail`.
+Debés enviar el `sessionID` y el `tempItemID` devuelto al crear el ítem.
+Con ambos valores se localiza exactamente el registro dentro de `TempOrderDetails`.

--- a/app/graphql/crud/temporderdetails.py
+++ b/app/graphql/crud/temporderdetails.py
@@ -37,11 +37,15 @@ def get_temporderdetails(db: Session) -> List[TempOrderDetails]:
 
 
 def get_temporderdetail_by_session(
-    db: Session, session_id: str
+    db: Session, session_id: str, temp_item_id: int
 ) -> Optional[TempOrderDetails]:
+    """Obtener un TempOrderDetail específico de una sesión"""
     return (
         db.query(TempOrderDetails)
-        .filter(TempOrderDetails.OrderSessionID == session_id)
+        .filter(
+            TempOrderDetails.OrderSessionID == session_id,
+            TempOrderDetails.TempOrderItemID == temp_item_id,
+        )
         .first()
     )
 
@@ -70,10 +74,11 @@ def create_temporderdetails(
 
 
 def update_temporderdetails(
-    db: Session, session_id: str, data: TempOrderDetailsUpdate
+    db: Session, session_id: str, temp_item_id: int, data: TempOrderDetailsUpdate
 ) -> Optional[TempOrderDetails]:
-    # Buscar el registro por OrderSessionID
-    obj = get_temporderdetail_by_session(db, session_id)
+    """Actualizar un item temporal usando session y TempOrderItemID"""
+    # Buscar el registro por OrderSessionID y TempOrderItemID
+    obj = get_temporderdetail_by_session(db, session_id, temp_item_id)
     if not obj:
         return None
     
@@ -87,8 +92,9 @@ def update_temporderdetails(
     return obj
 
 
-def delete_temporderdetails(db: Session, session_id: str) -> Optional[TempOrderDetails]:
-    obj = get_temporderdetail_by_session(db, session_id)
+def delete_temporderdetails(db: Session, session_id: str, temp_item_id: int) -> Optional[TempOrderDetails]:
+    """Eliminar un item temporal específico"""
+    obj = get_temporderdetail_by_session(db, session_id, temp_item_id)
     if not obj:
         return None
     db.delete(obj)

--- a/app/graphql/mutations/temporderdetails.py
+++ b/app/graphql/mutations/temporderdetails.py
@@ -54,24 +54,26 @@ class TempOrderDetailsMutations:
 
     @strawberry.mutation
     def update_temporderdetail(
-        self, info: Info, sessionID: str, data: TempOrderDetailsUpdate
+        self, info: Info, sessionID: str, tempItemID: int, data: TempOrderDetailsUpdate
     ) -> Optional[TempOrderDetailsInDB]:
-        """Actualizar un item temporal por SessionID"""
+        """Actualizar un item temporal usando sessionID y tempItemID"""
         db_gen = get_db()
         db = next(db_gen)
         try:
-            updated = update_temporderdetails(db, sessionID, data)
+            updated = update_temporderdetails(db, sessionID, tempItemID, data)
             return obj_to_schema(TempOrderDetailsInDB, updated) if updated else None
         finally:
             db_gen.close()
 
     @strawberry.mutation
-    def delete_temporderdetail(self, info: Info, sessionID: str) -> bool:
-        """Eliminar un item temporal por SessionID"""
+    def delete_temporderdetail(
+        self, info: Info, sessionID: str, tempItemID: int
+    ) -> bool:
+        """Eliminar un item temporal específico"""
         db_gen = get_db()
         db = next(db_gen)
         try:
-            deleted = delete_temporderdetails(db, sessionID)
+            deleted = delete_temporderdetails(db, sessionID, tempItemID)
             return deleted is not None
         finally:
             db_gen.close()


### PR DESCRIPTION
## Summary
- update `get_temporderdetail_by_session` to locate a row by both session ID and `TempOrderItemID`
- adjust update/delete logic to take the temp item ID
- document how to update items with `tempItemID`

## Testing
- `python -m py_compile app/graphql/crud/temporderdetails.py app/graphql/mutations/temporderdetails.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872bdee5b6c8323a9792264afd441d8