### PR TITLE
Fix temp item mutations and add edit button

### DIFF
--- a/frontend/src/components/ItemConfirmationModal.jsx
+++ b/frontend/src/components/ItemConfirmationModal.jsx
@@ -6,6 +6,7 @@ export default function ItemConfirmationModal({
     item,
     onClose,
     onConfirm,
+    confirmLabel = "Agregar al Pedido",
 }) {
     const [quantity, setQuantity] = useState(1);
     const [price, setPrice] = useState(0);
@@ -15,7 +16,7 @@ export default function ItemConfirmationModal({
         if (item) {
             console.log("ItemConfirmationModal - Item recibido:", item); // Debug log
             setPrice(item.price || 0);
-            setQuantity(1);
+            setQuantity(item.quantity || 1);
         }
     }, [item]);
 
@@ -188,7 +189,7 @@ export default function ItemConfirmationModal({
                             onClick={handleConfirm}
                             className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                         >
-                            Agregar al Pedido
+                            {confirmLabel}
                         </button>
                     </div>
                 </div>

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -613,8 +613,8 @@ export const MUTATIONS = {
         }
     `,
     UPDATE_TEMPORDERDETAIL: `
-        mutation UpdateTemporderdetail($sessionID: String!, $input: TempOrderDetailsUpdate!) {
-            updateTemporderdetail(sessionID: $sessionID, data: $input) {
+        mutation UpdateTemporderdetail($sessionID: String!, $tempItemID: Int!, $input: TempOrderDetailsUpdate!) {
+            updateTemporderdetail(sessionID: $sessionID, tempItemID: $tempItemID, data: $input) {
                 OrderSessionID
                 ItemID
                 Quantity
@@ -625,8 +625,8 @@ export const MUTATIONS = {
         }
     `,
     DELETE_TEMPORDERDETAIL: `
-        mutation DeleteTemporderdetail($sessionID: String!) {
-            deleteTemporderdetail(sessionID: $sessionID)
+        mutation DeleteTemporderdetail($sessionID: String!, $tempItemID: Int!) {
+            deleteTemporderdetail(sessionID: $sessionID, tempItemID: $tempItemID)
         }
     `,
 

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1242,11 +1242,11 @@ export const tempOrderOperations = {
         }
     },
 
-    async updateTempItem(sessionID, data) {
+    async updateTempItem(sessionID, tempItemID, data) {
         try {
             const result = await graphqlClient.mutation(
                 MUTATIONS.UPDATE_TEMPORDERDETAIL,
-                { sessionID, input: data }
+                { sessionID, tempItemID, input: data }
             );
             return result.updateTemporderdetail;
         } catch (error) {
@@ -1255,10 +1255,11 @@ export const tempOrderOperations = {
         }
     },
 
-    async deleteTempItem(sessionID) {
+    async deleteTempItem(sessionID, tempItemID) {
         try {
             await graphqlClient.mutation(MUTATIONS.DELETE_TEMPORDERDETAIL, {
                 sessionID,
+                tempItemID,
             });
             return true;
         } catch (error) {


### PR DESCRIPTION
## Summary
- fix GraphQL mutations for temp order details to send `tempItemID`
- adjust frontend operations to include `tempItemID`
- allow editing order items with a modal
- update `ItemConfirmationModal` to handle editing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872f1990ecc832386e3dab1626937cf