### PR TITLE
Fix temp item operations

### DIFF
--- a/app/graphql/crud/temporderdetails.py
+++ b/app/graphql/crud/temporderdetails.py
@@ -37,14 +37,16 @@ def get_temporderdetails(db: Session) -> List[TempOrderDetails]:
 
 
 def get_temporderdetail_by_session(
-    db: Session, session_id: str, temp_item_id: int
+    db: Session,
+    session_id: str,
+    item_id: int,
 ) -> Optional[TempOrderDetails]:
-    """Obtener un TempOrderDetail específico de una sesión"""
+    """Obtener un ``TempOrderDetail`` por ``OrderSessionID`` e ``ItemID``"""
     return (
         db.query(TempOrderDetails)
         .filter(
             TempOrderDetails.OrderSessionID == session_id,
-            TempOrderDetails.TempOrderItemID == temp_item_id,
+            TempOrderDetails.ItemID == item_id,
         )
         .first()
     )
@@ -74,11 +76,14 @@ def create_temporderdetails(
 
 
 def update_temporderdetails(
-    db: Session, session_id: str, temp_item_id: int, data: TempOrderDetailsUpdate
+    db: Session,
+    session_id: str,
+    item_id: int,
+    data: TempOrderDetailsUpdate,
 ) -> Optional[TempOrderDetails]:
-    """Actualizar un item temporal usando session y TempOrderItemID"""
-    # Buscar el registro por OrderSessionID y TempOrderItemID
-    obj = get_temporderdetail_by_session(db, session_id, temp_item_id)
+    """Actualizar un item temporal usando ``OrderSessionID`` e ``ItemID``"""
+    # Buscar el registro por OrderSessionID e ItemID
+    obj = get_temporderdetail_by_session(db, session_id, item_id)
     if not obj:
         return None
     
@@ -92,9 +97,13 @@ def update_temporderdetails(
     return obj
 
 
-def delete_temporderdetails(db: Session, session_id: str, temp_item_id: int) -> Optional[TempOrderDetails]:
+def delete_temporderdetails(
+    db: Session,
+    session_id: str,
+    item_id: int,
+) -> Optional[TempOrderDetails]:
     """Eliminar un item temporal específico"""
-    obj = get_temporderdetail_by_session(db, session_id, temp_item_id)
+    obj = get_temporderdetail_by_session(db, session_id, item_id)
     if not obj:
         return None
     db.delete(obj)

--- a/app/graphql/mutations/temporderdetails.py
+++ b/app/graphql/mutations/temporderdetails.py
@@ -54,26 +54,33 @@ class TempOrderDetailsMutations:
 
     @strawberry.mutation
     def update_temporderdetail(
-        self, info: Info, sessionID: str, tempItemID: int, data: TempOrderDetailsUpdate
+        self,
+        info: Info,
+        sessionID: str,
+        itemID: int,
+        data: TempOrderDetailsUpdate,
     ) -> Optional[TempOrderDetailsInDB]:
-        """Actualizar un item temporal usando sessionID y tempItemID"""
+        """Actualizar un item temporal usando ``sessionID`` e ``itemID``"""
         db_gen = get_db()
         db = next(db_gen)
         try:
-            updated = update_temporderdetails(db, sessionID, tempItemID, data)
+            updated = update_temporderdetails(db, sessionID, itemID, data)
             return obj_to_schema(TempOrderDetailsInDB, updated) if updated else None
         finally:
             db_gen.close()
 
     @strawberry.mutation
     def delete_temporderdetail(
-        self, info: Info, sessionID: str, tempItemID: int
+        self,
+        info: Info,
+        sessionID: str,
+        itemID: int,
     ) -> bool:
         """Eliminar un item temporal específico"""
         db_gen = get_db()
         db = next(db_gen)
         try:
-            deleted = delete_temporderdetails(db, sessionID, tempItemID)
+            deleted = delete_temporderdetails(db, sessionID, itemID)
             return deleted is not None
         finally:
             db_gen.close()

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -613,8 +613,8 @@ export const MUTATIONS = {
         }
     `,
     UPDATE_TEMPORDERDETAIL: `
-        mutation UpdateTemporderdetail($sessionID: String!, $tempItemID: Int!, $input: TempOrderDetailsUpdate!) {
-            updateTemporderdetail(sessionID: $sessionID, tempItemID: $tempItemID, data: $input) {
+        mutation UpdateTemporderdetail($sessionID: String!, $itemID: Int!, $input: TempOrderDetailsUpdate!) {
+            updateTemporderdetail(sessionID: $sessionID, itemID: $itemID, data: $input) {
                 OrderSessionID
                 ItemID
                 Quantity
@@ -625,8 +625,8 @@ export const MUTATIONS = {
         }
     `,
     DELETE_TEMPORDERDETAIL: `
-        mutation DeleteTemporderdetail($sessionID: String!, $tempItemID: Int!) {
-            deleteTemporderdetail(sessionID: $sessionID, tempItemID: $tempItemID)
+        mutation DeleteTemporderdetail($sessionID: String!, $itemID: Int!) {
+            deleteTemporderdetail(sessionID: $sessionID, itemID: $itemID)
         }
     `,
 

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1242,11 +1242,11 @@ export const tempOrderOperations = {
         }
     },
 
-    async updateTempItem(sessionID, tempItemID, data) {
+    async updateTempItem(sessionID, itemID, data) {
         try {
             const result = await graphqlClient.mutation(
                 MUTATIONS.UPDATE_TEMPORDERDETAIL,
-                { sessionID, tempItemID, input: data }
+                { sessionID, itemID, input: data }
             );
             return result.updateTemporderdetail;
         } catch (error) {
@@ -1255,11 +1255,11 @@ export const tempOrderOperations = {
         }
     },
 
-    async deleteTempItem(sessionID, tempItemID) {
+    async deleteTempItem(sessionID, itemID) {
         try {
             await graphqlClient.mutation(MUTATIONS.DELETE_TEMPORDERDETAIL, {
                 sessionID,
-                tempItemID,
+                itemID,
             });
             return true;
         } catch (error) {


### PR DESCRIPTION
## Summary
- remove `TempOrderItemID` usage from CRUD operations
- adjust GraphQL mutations/resolvers to identify temp items by `itemID`
- update frontend GraphQL operations and mutations

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872f62a80e48323ad5e76800a009333