### PR TITLE
Fix order mutation queries

### DIFF
--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -537,27 +537,31 @@ export const MUTATIONS = {
     CREATE_ORDER: `
         mutation CreateOrder($input: OrdersCreate!) {
             createOrder(data: $input) {
-                OrderID
-                CompanyID
-                BranchID
-                Date_
-                ClientID
-                CarID
-                IsService
-                ServiceTypeID
-                Mileage
-                NextServiceMileage
-                Notes
-                SaleConditionID
-                DiscountID
-                Subtotal
-                Total
-                VAT
-                UserID
-                DocumentID
-                PriceListID
-                OrderStatusID
-                WarehouseID
+                order {
+                    OrderID
+                    CompanyID
+                    BranchID
+                    Date_
+                    ClientID
+                    CarID
+                    IsService
+                    ServiceTypeID
+                    Mileage
+                    NextServiceMileage
+                    Notes
+                    SaleConditionID
+                    DiscountID
+                    Subtotal
+                    Total
+                    VAT
+                    UserID
+                    DocumentID
+                    PriceListID
+                    OrderStatusID
+                    WarehouseID
+                }
+                sessionID
+                message
             }
         }
     `,
@@ -565,27 +569,31 @@ export const MUTATIONS = {
     UPDATE_ORDER: `
         mutation UpdateOrder($orderID: Int!, $input: OrdersUpdate!) {
             updateOrder(orderID: $orderID, data: $input) {
-                OrderID
-                CompanyID
-                BranchID
-                Date_
-                ClientID
-                CarID
-                IsService
-                ServiceTypeID
-                Mileage
-                NextServiceMileage
-                Notes
-                SaleConditionID
-                DiscountID
-                Subtotal
-                Total
-                VAT
-                UserID
-                DocumentID
-                PriceListID
-                OrderStatusID
-                WarehouseID
+                order {
+                    OrderID
+                    CompanyID
+                    BranchID
+                    Date_
+                    ClientID
+                    CarID
+                    IsService
+                    ServiceTypeID
+                    Mileage
+                    NextServiceMileage
+                    Notes
+                    SaleConditionID
+                    DiscountID
+                    Subtotal
+                    Total
+                    VAT
+                    UserID
+                    DocumentID
+                    PriceListID
+                    OrderStatusID
+                    WarehouseID
+                }
+                sessionID
+                message
             }
         }
     `,

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1129,7 +1129,7 @@ export const orderOperations = {
                 input: preparedData
             });
 
-            return data.createOrder;
+            return data.createOrder.order;
         } catch (error) {
             console.error("Error creando orden:", error);
             throw error;
@@ -1167,7 +1167,7 @@ export const orderOperations = {
                 input: preparedData
             });
 
-            return data.updateOrder;
+            return data.updateOrder.order;
         } catch (error) {
             console.error("Error actualizando orden:", error);
             throw error;


### PR DESCRIPTION
## Summary
- adjust `CREATE_ORDER` and `UPDATE_ORDER` mutations to match `OrderResponse` schema
- update order operations to return the nested `order` data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872fbb1cbd883239ad6d34dcdb89fb1