### PR TITLE
Fix order editing session

### DIFF
--- a/frontend/src/pages/OrderCreate.jsx
+++ b/frontend/src/pages/OrderCreate.jsx
@@ -386,7 +386,8 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
             } else {
                 response = await orderOperations.createOrder(orderData);
             }
-            alert("Orden guardada correctamente. ID: " + response.OrderID);
+            const order = response.order || response; // compatibilidad
+            alert("Orden guardada correctamente. ID: " + order.OrderID);
 
             // Limpiar formulario después de crear exitosamente
             setFormData({

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -537,27 +537,31 @@ export const MUTATIONS = {
     CREATE_ORDER: `
         mutation CreateOrder($input: OrdersCreate!) {
             createOrder(data: $input) {
-                OrderID
-                CompanyID
-                BranchID
-                Date_
-                ClientID
-                CarID
-                IsService
-                ServiceTypeID
-                Mileage
-                NextServiceMileage
-                Notes
-                SaleConditionID
-                DiscountID
-                Subtotal
-                Total
-                VAT
-                UserID
-                DocumentID
-                PriceListID
-                OrderStatusID
-                WarehouseID
+                order {
+                    OrderID
+                    CompanyID
+                    BranchID
+                    Date_
+                    ClientID
+                    CarID
+                    IsService
+                    ServiceTypeID
+                    Mileage
+                    NextServiceMileage
+                    Notes
+                    SaleConditionID
+                    DiscountID
+                    Subtotal
+                    Total
+                    VAT
+                    UserID
+                    DocumentID
+                    PriceListID
+                    OrderStatusID
+                    WarehouseID
+                }
+                sessionID
+                message
             }
         }
     `,
@@ -565,27 +569,31 @@ export const MUTATIONS = {
     UPDATE_ORDER: `
         mutation UpdateOrder($orderID: Int!, $input: OrdersUpdate!) {
             updateOrder(orderID: $orderID, data: $input) {
-                OrderID
-                CompanyID
-                BranchID
-                Date_
-                ClientID
-                CarID
-                IsService
-                ServiceTypeID
-                Mileage
-                NextServiceMileage
-                Notes
-                SaleConditionID
-                DiscountID
-                Subtotal
-                Total
-                VAT
-                UserID
-                DocumentID
-                PriceListID
-                OrderStatusID
-                WarehouseID
+                order {
+                    OrderID
+                    CompanyID
+                    BranchID
+                    Date_
+                    ClientID
+                    CarID
+                    IsService
+                    ServiceTypeID
+                    Mileage
+                    NextServiceMileage
+                    Notes
+                    SaleConditionID
+                    DiscountID
+                    Subtotal
+                    Total
+                    VAT
+                    UserID
+                    DocumentID
+                    PriceListID
+                    OrderStatusID
+                    WarehouseID
+                }
+                sessionID
+                message
             }
         }
     `,


### PR DESCRIPTION
## Summary
- always copy order details to temp table when updating an order
- return full response object from order mutations
- adjust order page to handle updated mutation responses

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872fbb1cbd883239ad6d34dcdb89fb1