### PR TITLE
Fix order editing session

### DIFF
--- a/frontend/src/pages/OrderCreate.jsx
+++ b/frontend/src/pages/OrderCreate.jsx
@@ -87,22 +87,30 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
                 warehouseId: String(initialOrder.WarehouseID || "")
             });
 
-            orderOperations
-                .getOrderById(initialOrder.OrderID)
-                .then((ord) => {
-                    if (ord && ord.Items) {
-                        const parsed = ord.Items.map((d) => ({
-                            itemID: d.ItemID,
-                            code: "",
-                            description: d.Description || "",
-                            quantity: d.Quantity,
-                            price: d.UnitPrice,
-                            subtotal: d.Quantity * d.UnitPrice,
-                        }));
-                        setItems(parsed);
-                    }
-                })
-                .catch(() => {});
+            (async () => {
+                try {
+                    const sid = await tempOrderOperations.loadOrderForEditing(
+                        initialOrder.OrderID,
+                        userInfo?.userId || initialOrder.UserID,
+                        userInfo?.companyId || initialOrder.CompanyID,
+                        userInfo?.branchId || initialOrder.BranchID
+                    );
+                    setSessionId(sid);
+                    const tempItems = await tempOrderOperations.getTempItems(sid);
+                    const parsed = tempItems.map((d) => ({
+                        itemID: d.ItemID,
+                        code: "",
+                        description: d.Description || "",
+                        quantity: d.Quantity,
+                        price: d.UnitPrice,
+                        subtotal: d.Quantity * d.UnitPrice,
+                        orderSessionID: d.OrderSessionID,
+                    }));
+                    setItems(parsed);
+                } catch (err) {
+                    console.error("Error cargando items temporales:", err);
+                }
+            })();
         }
     }, [initialOrder]);
 
@@ -386,7 +394,8 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
             } else {
                 response = await orderOperations.createOrder(orderData);
             }
-            alert("Orden guardada correctamente. ID: " + response.OrderID);
+            const order = response.order || response; // compatibilidad
+            alert("Orden guardada correctamente. ID: " + order.OrderID);
 
             // Limpiar formulario después de crear exitosamente
             setFormData({

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -537,27 +537,31 @@ export const MUTATIONS = {
     CREATE_ORDER: `
         mutation CreateOrder($input: OrdersCreate!) {
             createOrder(data: $input) {
-                OrderID
-                CompanyID
-                BranchID
-                Date_
-                ClientID
-                CarID
-                IsService
-                ServiceTypeID
-                Mileage
-                NextServiceMileage
-                Notes
-                SaleConditionID
-                DiscountID
-                Subtotal
-                Total
-                VAT
-                UserID
-                DocumentID
-                PriceListID
-                OrderStatusID
-                WarehouseID
+                order {
+                    OrderID
+                    CompanyID
+                    BranchID
+                    Date_
+                    ClientID
+                    CarID
+                    IsService
+                    ServiceTypeID
+                    Mileage
+                    NextServiceMileage
+                    Notes
+                    SaleConditionID
+                    DiscountID
+                    Subtotal
+                    Total
+                    VAT
+                    UserID
+                    DocumentID
+                    PriceListID
+                    OrderStatusID
+                    WarehouseID
+                }
+                sessionID
+                message
             }
         }
     `,
@@ -565,27 +569,31 @@ export const MUTATIONS = {
     UPDATE_ORDER: `
         mutation UpdateOrder($orderID: Int!, $input: OrdersUpdate!) {
             updateOrder(orderID: $orderID, data: $input) {
-                OrderID
-                CompanyID
-                BranchID
-                Date_
-                ClientID
-                CarID
-                IsService
-                ServiceTypeID
-                Mileage
-                NextServiceMileage
-                Notes
-                SaleConditionID
-                DiscountID
-                Subtotal
-                Total
-                VAT
-                UserID
-                DocumentID
-                PriceListID
-                OrderStatusID
-                WarehouseID
+                order {
+                    OrderID
+                    CompanyID
+                    BranchID
+                    Date_
+                    ClientID
+                    CarID
+                    IsService
+                    ServiceTypeID
+                    Mileage
+                    NextServiceMileage
+                    Notes
+                    SaleConditionID
+                    DiscountID
+                    Subtotal
+                    Total
+                    VAT
+                    UserID
+                    DocumentID
+                    PriceListID
+                    OrderStatusID
+                    WarehouseID
+                }
+                sessionID
+                message
             }
         }
     `,
@@ -627,6 +635,31 @@ export const MUTATIONS = {
     DELETE_TEMPORDERDETAIL: `
         mutation DeleteTemporderdetail($sessionID: String!, $itemID: Int!) {
             deleteTemporderdetail(sessionID: $sessionID, itemID: $itemID)
+        }
+    `,
+
+    LOAD_ORDER_FOR_EDITING: `
+        mutation LoadOrderForEditing($orderID: Int!, $userID: Int!, $companyID: Int!, $branchID: Int!) {
+            loadOrderForEditing(orderID: $orderID, userID: $userID, companyID: $companyID, branchID: $branchID)
+        }
+    `,
+
+    GET_TEMP_ITEMS_BY_SESSION: `
+        query GetTempItemsBySession($sessionID: String!) {
+            temporderdetailsBySession(sessionID: $sessionID) {
+                OrderDetailID
+                OrderID
+                OrderSessionID
+                CompanyID
+                BranchID
+                UserID
+                ItemID
+                Quantity
+                WarehouseID
+                PriceListID
+                UnitPrice
+                Description
+            }
         }
     `,
 

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1267,6 +1267,32 @@ export const tempOrderOperations = {
             throw error;
         }
     },
+
+    async loadOrderForEditing(orderID, userID, companyID, branchID) {
+        try {
+            const result = await graphqlClient.mutation(
+                MUTATIONS.LOAD_ORDER_FOR_EDITING,
+                { orderID, userID, companyID, branchID }
+            );
+            return result.loadOrderForEditing;
+        } catch (error) {
+            console.error("Error cargando orden para edición:", error);
+            throw error;
+        }
+    },
+
+    async getTempItems(sessionID) {
+        try {
+            const result = await graphqlClient.query(
+                MUTATIONS.GET_TEMP_ITEMS_BY_SESSION,
+                { sessionID }
+            );
+            return result.temporderdetailsBySession || [];
+        } catch (error) {
+            console.error("Error obteniendo items temporales:", error);
+            throw error;
+        }
+    },
 };
 
 export const companyOperations = {


### PR DESCRIPTION
## Summary
- always copy order details to temp table when updating an order
- return full response object from order mutations
- adjust order page to handle updated mutation responses
- load items via session when editing an order

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872fbb1cbd883239ad6d34dcdb89fb1