### PR TITLE
Fix editing workflow to store order items

### DIFF
--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -607,6 +607,18 @@ export const MUTATIONS = {
         }
     `,
 
+    FINALIZE_ORDER: `
+        mutation FinalizeOrder($orderID: Int!, $sessionID: String!) {
+            finalizeOrder(orderID: $orderID, sessionID: $sessionID) {
+                order {
+                    OrderID
+                }
+                sessionID
+                message
+            }
+        }
+    `,
+
     // ====== TEMPORARY ORDER DETAILS ======
     CREATE_TEMPORDERDETAIL: `
         mutation CreateTemporderdetail($input: TempOrderDetailsCreate!) {

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1129,7 +1129,7 @@ export const orderOperations = {
                 input: preparedData
             });
 
-            return data.createOrder.order;
+            return data.createOrder;
         } catch (error) {
             console.error("Error creando orden:", error);
             throw error;
@@ -1167,7 +1167,7 @@ export const orderOperations = {
                 input: preparedData
             });
 
-            return data.updateOrder.order;
+            return data.updateOrder;
         } catch (error) {
             console.error("Error actualizando orden:", error);
             throw error;
@@ -1183,6 +1183,19 @@ export const orderOperations = {
             return data.deleteOrder;
         } catch (error) {
             console.error("Error eliminando orden:", error);
+            throw error;
+        }
+    },
+
+    async finalizeOrder(orderID, sessionID) {
+        try {
+            const result = await graphqlClient.mutation(
+                MUTATIONS.FINALIZE_ORDER,
+                { orderID, sessionID }
+            );
+            return result.finalizeOrder;
+        } catch (error) {
+            console.error("Error finalizando orden:", error);
             throw error;
         }
     },


### PR DESCRIPTION
## Summary
- add mutation for finalizing orders in GraphQL helpers
- expose finalizeOrder in the operations client
- finalize orders from `OrderCreate` page when saving

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873047f54848323ac57c8b2d48799ab