### PR TITLE
Fix temp order updates

### DIFF
--- a/app/graphql/mutations/temporderdetails.py
+++ b/app/graphql/mutations/temporderdetails.py
@@ -59,12 +59,19 @@ class TempOrderDetailsMutations:
         sessionID: str,
         itemID: int,
         data: TempOrderDetailsUpdate,
+        orderDetailID: Optional[int] = None,
     ) -> Optional[TempOrderDetailsInDB]:
-        """Actualizar un item temporal usando ``sessionID`` e ``itemID``"""
+        """Actualizar un item temporal usando ``sessionID`` e ``itemID``.
+
+        ``orderDetailID`` es opcional y se utiliza cuando el item proviene de un
+        ``OrderDetail`` existente para evitar actualizar múltiples registros.
+        """
         db_gen = get_db()
         db = next(db_gen)
         try:
-            updated = update_temporderdetails(db, sessionID, itemID, data)
+            updated = update_temporderdetails(
+                db, sessionID, itemID, data, orderDetailID
+            )
             return obj_to_schema(TempOrderDetailsInDB, updated) if updated else None
         finally:
             db_gen.close()
@@ -75,12 +82,13 @@ class TempOrderDetailsMutations:
         info: Info,
         sessionID: str,
         itemID: int,
+        orderDetailID: Optional[int] = None,
     ) -> bool:
         """Eliminar un item temporal específico"""
         db_gen = get_db()
         db = next(db_gen)
         try:
-            deleted = delete_temporderdetails(db, sessionID, itemID)
+            deleted = delete_temporderdetails(db, sessionID, itemID, orderDetailID)
             return deleted is not None
         finally:
             db_gen.close()

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -618,6 +618,11 @@ export const MUTATIONS = {
             }
         }
     `,
+    CANCEL_ORDER_EDITING: `
+        mutation CancelOrderEditing($orderID: Int!, $sessionID: String!) {
+            cancelOrderEditing(orderID: $orderID, sessionID: $sessionID)
+        }
+    `,
 
     // ====== TEMPORARY ORDER DETAILS ======
     CREATE_TEMPORDERDETAIL: `
@@ -633,8 +638,8 @@ export const MUTATIONS = {
         }
     `,
     UPDATE_TEMPORDERDETAIL: `
-        mutation UpdateTemporderdetail($sessionID: String!, $itemID: Int!, $input: TempOrderDetailsUpdate!) {
-            updateTemporderdetail(sessionID: $sessionID, itemID: $itemID, data: $input) {
+        mutation UpdateTemporderdetail($sessionID: String!, $itemID: Int!, $orderDetailID: Int, $input: TempOrderDetailsUpdate!) {
+            updateTemporderdetail(sessionID: $sessionID, itemID: $itemID, orderDetailID: $orderDetailID, data: $input) {
                 OrderSessionID
                 ItemID
                 Quantity
@@ -645,8 +650,8 @@ export const MUTATIONS = {
         }
     `,
     DELETE_TEMPORDERDETAIL: `
-        mutation DeleteTemporderdetail($sessionID: String!, $itemID: Int!) {
-            deleteTemporderdetail(sessionID: $sessionID, itemID: $itemID)
+        mutation DeleteTemporderdetail($sessionID: String!, $itemID: Int!, $orderDetailID: Int) {
+            deleteTemporderdetail(sessionID: $sessionID, itemID: $itemID, orderDetailID: $orderDetailID)
         }
     `,
 

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1200,6 +1200,19 @@ export const orderOperations = {
         }
     },
 
+    async cancelOrderEditing(orderID, sessionID) {
+        try {
+            await graphqlClient.mutation(MUTATIONS.CANCEL_ORDER_EDITING, {
+                orderID,
+                sessionID,
+            });
+            return true;
+        } catch (error) {
+            console.error("Error cancelando edición de orden:", error);
+            throw error;
+        }
+    },
+
     // Función auxiliar para obtener datos del formulario de órdenes
     async getOrderFormData() {
         try {
@@ -1255,11 +1268,11 @@ export const tempOrderOperations = {
         }
     },
 
-    async updateTempItem(sessionID, itemID, data) {
+    async updateTempItem(sessionID, itemID, data, orderDetailID = null) {
         try {
             const result = await graphqlClient.mutation(
                 MUTATIONS.UPDATE_TEMPORDERDETAIL,
-                { sessionID, itemID, input: data }
+                { sessionID, itemID, orderDetailID, input: data }
             );
             return result.updateTemporderdetail;
         } catch (error) {
@@ -1268,11 +1281,12 @@ export const tempOrderOperations = {
         }
     },
 
-    async deleteTempItem(sessionID, itemID) {
+    async deleteTempItem(sessionID, itemID, orderDetailID = null) {
         try {
             await graphqlClient.mutation(MUTATIONS.DELETE_TEMPORDERDETAIL, {
                 sessionID,
                 itemID,
+                orderDetailID,
             });
             return true;
         } catch (error) {


### PR DESCRIPTION
## Summary
- allow getting a TempOrderDetail by OrderDetailID
- let update/delete mutations accept OrderDetailID
- wire new parameter in frontend operations
- store OrderDetailID while editing orders
- clear temporary items when the order window closes

## Testing
- `npm run lint`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_687330f468908323a3114080758c2c62