### PR TITLE
Fix order item loading and cleanup queries

### DIFF
--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -20,19 +20,19 @@ export default function Login() {
 
         try {
             // Usar AuthHelper para el login
-            const result = await AuthHelper.login(nickname, password);
+            const data = await AuthHelper.login(nickname, password);
 
-            if (!result.success) {
-                throw new Error(result.message || "Credenciales inválidas");
+            if (!data.success) {
+                throw new Error(data.message || "Credenciales inválidas");
             }
 
             // Adaptar la respuesta al formato esperado por UserContext
-            const data = {
-                UserID: result.user.UserID,
-                Nickname: result.user.Nickname,
-                FullName: result.user.FullName,
-                IsActive: result.user.IsActive,
-                userAccesses: result.user.UserAccess.map(access => ({
+            const userData = {
+                UserID: data.user.UserID,
+                Nickname: data.user.Nickname,
+                FullName: data.user.FullName,
+                IsActive: data.user.IsActive,
+                userAccesses: data.user.UserAccess.map(access => ({
                     userID: access.UserID,
                     companyID: access.CompanyID,
                     companyName: access.Company,
@@ -44,7 +44,7 @@ export default function Login() {
             };
 
             // Actualizar contexto
-            login(data);
+            login(userData);
 
             // Verificar si hay una redirección pendiente
             const redirectPath = sessionStorage.getItem("redirectAfterLogin");

--- a/frontend/src/pages/Clients.jsx
+++ b/frontend/src/pages/Clients.jsx
@@ -104,8 +104,8 @@ export default function Clients() {
 
     const runDiagnostic = async () => {
         setDebugInfo("Ejecutando diagnóstico completo...");
-        const result = await diagnosticGraphQL();
-        setDebugInfo(result ? "Diagnóstico exitoso" : "Diagnóstico falló - revisa la consola");
+        const data = await diagnosticGraphQL();
+        setDebugInfo(data ? "Diagnóstico exitoso" : "Diagnóstico falló - revisa la consola");
     };
 
     const handleCreateClient = () => {

--- a/frontend/src/pages/CompanyCreate.jsx
+++ b/frontend/src/pages/CompanyCreate.jsx
@@ -91,11 +91,11 @@ export default function CompanyCreate({ onClose, onSave, company: initialCompany
                             if (!file) return;
                             const reader = new FileReader();
                             reader.onload = (ev) => {
-                                const result = ev.target?.result;
-                                if (typeof result === "string") {
-                                    const base64 = result.split(",")[1] || result;
+                                const data = ev.target?.result;
+                                if (typeof data === "string") {
+                                    const base64 = data.split(",")[1] || data;
                                     setLogo(base64);
-                                    setLogoPreview(result);
+                                    setLogoPreview(data);
                                 }
                             };
                             reader.readAsDataURL(file);

--- a/frontend/src/pages/OrderCreate.jsx
+++ b/frontend/src/pages/OrderCreate.jsx
@@ -132,7 +132,14 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
                 }
             })();
         }
-    }, [initialOrder]);
+    }, [
+        initialOrder,
+        formData.priceListId,
+        formData.warehouseId,
+        userInfo?.userId,
+        userInfo?.companyId,
+        userInfo?.branchId,
+    ]);
 
     useEffect(() => {
         const fetchData = async () => {

--- a/frontend/src/pages/Suppliers.jsx
+++ b/frontend/src/pages/Suppliers.jsx
@@ -84,8 +84,8 @@ export default function Suppliers() {
 
     const runDiagnostic = async () => {
         setDebugInfo("Ejecutando diagnóstico completo...");
-        const result = await diagnosticGraphQL();
-        setDebugInfo(result ? "Diagnóstico exitoso" : "Diagnóstico falló - revisa la consola");
+        const data = await diagnosticGraphQL();
+        setDebugInfo(data ? "Diagnóstico exitoso" : "Diagnóstico falló - revisa la consola");
     };
 
     const handleCreateSupplier = () => {

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -661,25 +661,6 @@ export const MUTATIONS = {
         }
     `,
 
-    GET_TEMP_ITEMS_BY_SESSION: `
-        query GetTempItemsBySession($sessionID: String!) {
-            temporderdetailsBySession(sessionID: $sessionID) {
-                OrderDetailID
-                OrderID
-                OrderSessionID
-                CompanyID
-                BranchID
-                UserID
-                ItemID
-                Quantity
-                WarehouseID
-                PriceListID
-                UnitPrice
-                Description
-            }
-        }
-    `,
-
     // ROLES
     CREATE_ROLE: `
         mutation CreateRole($input: RolesCreate!) {

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1189,11 +1189,11 @@ export const orderOperations = {
 
     async finalizeOrder(orderID, sessionID) {
         try {
-            const result = await graphqlClient.mutation(
+            const data = await graphqlClient.mutation(
                 MUTATIONS.FINALIZE_ORDER,
                 { orderID, sessionID }
             );
-            return result.finalizeOrder;
+            return data.finalizeOrder;
         } catch (error) {
             console.error("Error finalizando orden:", error);
             throw error;
@@ -1255,26 +1255,26 @@ export const orderOperations = {
 
 // ===== FUNCIONES PARA ITEMS TEMPORALES =====
 export const tempOrderOperations = {
-    async createTempItem(data) {
+    async createTempItem(itemData) {
         try {
-            const result = await graphqlClient.mutation(
+            const data = await graphqlClient.mutation(
                 MUTATIONS.CREATE_TEMPORDERDETAIL,
-                { input: data }
+                { input: itemData }
             );
-            return result.createTemporderdetail;
+            return data.createTemporderdetail;
         } catch (error) {
             console.error("Error creando item temporal:", error);
             throw error;
         }
     },
 
-    async updateTempItem(sessionID, itemID, data, orderDetailID = null) {
+    async updateTempItem(sessionID, itemID, itemData, orderDetailID = null) {
         try {
-            const result = await graphqlClient.mutation(
+            const data = await graphqlClient.mutation(
                 MUTATIONS.UPDATE_TEMPORDERDETAIL,
-                { sessionID, itemID, orderDetailID, input: data }
+                { sessionID, itemID, orderDetailID, input: itemData }
             );
-            return result.updateTemporderdetail;
+            return data.updateTemporderdetail;
         } catch (error) {
             console.error("Error actualizando item temporal:", error);
             throw error;
@@ -1297,11 +1297,11 @@ export const tempOrderOperations = {
 
     async loadOrderForEditing(orderID, userID, companyID, branchID) {
         try {
-            const result = await graphqlClient.mutation(
+            const data = await graphqlClient.mutation(
                 MUTATIONS.LOAD_ORDER_FOR_EDITING,
                 { orderID, userID, companyID, branchID }
             );
-            return result.loadOrderForEditing;
+            return data.loadOrderForEditing;
         } catch (error) {
             console.error("Error cargando orden para edición:", error);
             throw error;
@@ -1310,11 +1310,11 @@ export const tempOrderOperations = {
 
     async getTempItems(sessionID) {
         try {
-            const result = await graphqlClient.query(
-                MUTATIONS.GET_TEMP_ITEMS_BY_SESSION,
+            const data = await graphqlClient.query(
+                QUERIES.GET_TEMP_ITEMS_BY_SESSION,
                 { sessionID }
             );
-            return result.temporderdetailsBySession || [];
+            return data.temporderdetailsBySession || [];
         } catch (error) {
             console.error("Error obteniendo items temporales:", error);
             throw error;

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -432,6 +432,25 @@ export const QUERIES = {
         }
     `,
 
+    GET_TEMP_ITEMS_BY_SESSION: `
+        query GetTempItemsBySession($sessionID: String!) {
+            temporderdetailsBySession(sessionID: $sessionID) {
+                OrderDetailID
+                OrderID
+                OrderSessionID
+                CompanyID
+                BranchID
+                UserID
+                ItemID
+                Quantity
+                WarehouseID
+                PriceListID
+                UnitPrice
+                Description
+            }
+        }
+    `,
+
     // PROVEEDORES
     GET_ALL_SUPPLIERS: `
         query GetAllSuppliers {


### PR DESCRIPTION
## Summary
- standardize variable naming across GraphQL operations
- move temp item query to queries file
- use new query in operations
- fix React hook dependencies in OrderCreate
- replace leftover `result` variables

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68735e440b108323901bfacc76272d38