### PR TITLE
Fix temp order item code retrieval

### DIFF
--- a/app/graphql/resolvers/temporderdetails.py
+++ b/app/graphql/resolvers/temporderdetails.py
@@ -3,6 +3,7 @@ import strawberry
 from typing import List, Optional
 from app.graphql.schemas.temporderdetails import TempOrderDetailsInDB
 from app.models.temporderdetails import TempOrderDetails
+from app.models.items import Items
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
 from strawberry.types import Info
@@ -27,9 +28,14 @@ class TemporderdetailsQuery:
         db_gen = get_db()
         db = next(db_gen)
         try:
-            items = db.query(TempOrderDetails).filter(
-                TempOrderDetails.OrderSessionID == sessionID
-            ).all()
+            items = (
+                db.query(TempOrderDetails)
+                .join(Items, TempOrderDetails.ItemID == Items.ItemID)
+                .filter(TempOrderDetails.OrderSessionID == sessionID)
+                .all()
+            )
+            for it in items:
+                it.ItemCode = it.items_.Code if it.items_ else None
             return list_to_schema(TempOrderDetailsInDB, items)
         finally:
             db_gen.close()

--- a/app/graphql/schemas/temporderdetails.py
+++ b/app/graphql/schemas/temporderdetails.py
@@ -42,6 +42,7 @@ class TempOrderDetailsInDB:
     BranchID: int
     UserID: int
     ItemID: int
+    ItemCode: Optional[str]
     Quantity: int
     WarehouseID: int
     PriceListID: int

--- a/app/models/temporderdetails.py
+++ b/app/models/temporderdetails.py
@@ -1,4 +1,4 @@
-﻿# app/models/temporderdetails.py
+# app/models/temporderdetails.py
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 from typing import Optional
 
-from sqlalchemy import Column, Integer, Unicode, DECIMAL, Uuid, Identity, PrimaryKeyConstraint, ForeignKeyConstraint, text
+from sqlalchemy import Column, Integer, Unicode, DECIMAL, Uuid, PrimaryKeyConstraint, ForeignKeyConstraint, text
 from sqlalchemy.orm import Mapped, relationship
 from app.db import Base
 
@@ -25,7 +25,7 @@ class TempOrderDetails(Base):
         ForeignKeyConstraint(['CompanyID'], ['CompanyData.CompanyID'], name='FK__TempOrder__Compa__0C85DE4D'),
         ForeignKeyConstraint(['ItemID'], ['Items.ItemID'], name='FK__TempOrder__ItemI__0F624AF8'),
         ForeignKeyConstraint(['OrderID'], ['Orders.OrderID'], name='FK_TempOrderDetails_Orders'),
-        ForeignKeyConstraint(['OrderDetailID'], ['OrderDetails.OrderDetailID'], name='FK_TempOrderDetails_OrderDetails'), 
+        ForeignKeyConstraint(['OrderDetailID'], ['OrderDetails.OrderDetailID'], name='FK_TempOrderDetails_OrderDetails'),
         ForeignKeyConstraint(['PriceListID'], ['PriceLists.PriceListID'], name='FK_TempOrderDetails_PriceLists'),
         ForeignKeyConstraint(['UserID'], ['Users.UserID'], name='FK__TempOrder__UserI__0E6E26BF'),
         ForeignKeyConstraint(['WarehouseID'], ['Warehouses.WarehouseID'], name='FK_TempOrderDetails_Warehouses'),

--- a/frontend/src/pages/OrderCreate.jsx
+++ b/frontend/src/pages/OrderCreate.jsx
@@ -116,7 +116,7 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
                     const tempItems = await tempOrderOperations.getTempItems(sid);
                     const parsed = tempItems.map((d) => ({
                         itemID: d.ItemID,
-                        code: "",
+                        code: d.ItemCode || "",
                         description: d.Description || "",
                         quantity: d.Quantity,
                         price: d.UnitPrice,

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -442,6 +442,7 @@ export const QUERIES = {
                 BranchID
                 UserID
                 ItemID
+                ItemCode
                 Quantity
                 WarehouseID
                 PriceListID


### PR DESCRIPTION
## Summary
- revert model to composite primary key and drop TempOrderItemID
- keep item code lookup via Items join
- expose ItemCode in temp order schema and queries

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687363325ce08323bccce69c16b15069