### PR TITLE
Remove TempOrderItemID references

### DIFF
--- a/app/graphql/schemas/temporderdetails.py
+++ b/app/graphql/schemas/temporderdetails.py
@@ -35,7 +35,6 @@ class TempOrderDetailsUpdate:
 
 @strawberry.type
 class TempOrderDetailsInDB:
-    TempOrderItemID: int
     OrderDetailID: Optional[int]
     OrderID: Optional[int]
     OrderSessionID: UUID

--- a/app/models/temporderdetails.py
+++ b/app/models/temporderdetails.py
@@ -29,17 +29,15 @@ class TempOrderDetails(Base):
         ForeignKeyConstraint(['PriceListID'], ['PriceLists.PriceListID'], name='FK_TempOrderDetails_PriceLists'),
         ForeignKeyConstraint(['UserID'], ['Users.UserID'], name='FK__TempOrder__UserI__0E6E26BF'),
         ForeignKeyConstraint(['WarehouseID'], ['Warehouses.WarehouseID'], name='FK_TempOrderDetails_Warehouses'),
-        # Clave primaria basada en un campo identidad
-        PrimaryKeyConstraint('TempOrderItemID', name='PK__TempOrde__AC4DF55EB1F17B71')
+        PrimaryKeyConstraint('OrderSessionID', 'ItemID', name='PK_TempOrderDetails')
     )
 
     # Campos obligatorios según la estructura de SQL Server
-    TempOrderItemID = Column(Integer, Identity(start=1, increment=1), primary_key=True)
     CompanyID = Column(Integer, nullable=False)
     BranchID = Column(Integer, nullable=False)
     UserID = Column(Integer, nullable=False)
-    OrderSessionID = Column(Uuid, server_default=text('(newid())'), nullable=False)
-    ItemID = Column(Integer, nullable=False)
+    OrderSessionID = Column(Uuid, server_default=text('(newid())'), nullable=False, primary_key=True)
+    ItemID = Column(Integer, nullable=False, primary_key=True)
     Quantity = Column(Integer, nullable=False)
     WarehouseID = Column(Integer, nullable=False)
     PriceListID = Column(Integer, nullable=False)

--- a/db/LubricentroDB2.dbml
+++ b/db/LubricentroDB2.dbml
@@ -531,14 +531,13 @@ Table OrderHistoryDetails {
 // ==========================================
 
 Table TempOrderDetails {
-  TempOrderItemID int [pk, increment]
   OrderDetailID int
   OrderID int [ref: > Orders.OrderID]
-  OrderSessionID uniqueidentifier [not null, default: `newid()`]
+  OrderSessionID uniqueidentifier [not null, default: `newid()`, pk]
   CompanyID int [not null, ref: > CompanyData.CompanyID]
   BranchID int [not null, ref: > Branches.BranchID]
   UserID int [not null, ref: > Users.UserID]
-  ItemID int [not null, ref: > Items.ItemID]
+  ItemID int [not null, ref: > Items.ItemID, pk]
   Quantity int [not null]
   WarehouseID int [not null, ref: > Warehouses.WarehouseID]
   PriceListID int [not null, ref: > PriceLists.PriceListID]

--- a/db/init_database.sql
+++ b/db/init_database.sql
@@ -759,11 +759,10 @@ GO
 SET QUOTED_IDENTIFIER ON
 GO
 CREATE TABLE [dbo].[TempOrderDetails](
-	[TempOrderItemID] [int] IDENTITY(1,1) NOT NULL,
-	[OrderDetailID] [int] NULL,
-	[OrderID] [int] NULL,
-	[OrderSessionID] [uniqueidentifier] NOT NULL,
-	[CompanyID] [int] NOT NULL,
+        [OrderDetailID] [int] NULL,
+        [OrderID] [int] NULL,
+        [OrderSessionID] [uniqueidentifier] NOT NULL,
+        [CompanyID] [int] NOT NULL,
 	[BranchID] [int] NOT NULL,
 	[UserID] [int] NOT NULL,
 	[ItemID] [int] NOT NULL,
@@ -771,11 +770,7 @@ CREATE TABLE [dbo].[TempOrderDetails](
 	[WarehouseID] [int] NOT NULL,
 	[PriceListID] [int] NOT NULL,
 	[UnitPrice] [decimal](10, 2) NOT NULL,
-	[Description] [nvarchar](200) NOT NULL,
- CONSTRAINT [PK__TempOrde__AC4DF55EB1F17B71] PRIMARY KEY CLUSTERED 
-(
-	[TempOrderItemID] ASC
-)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+        [Description] [nvarchar](200) NOT NULL
 ) ON [PRIMARY]
 GO
 /****** Object:  Table [dbo].[TempStockEntries]    Script Date: 9/7/2025 01:07:52 ******/

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -435,7 +435,6 @@ export const QUERIES = {
     GET_TEMP_ITEMS_BY_SESSION: `
         query GetTempItemsBySession($sessionID: String!) {
             temporderdetailsBySession(sessionID: $sessionID) {
-                TempOrderItemID
                 OrderDetailID
                 OrderID
                 OrderSessionID


### PR DESCRIPTION
## Summary
- drop TempOrderItemID column from the temp order details model
- remove TempOrderItemID field from GraphQL schema
- update GraphQL query for temporary items
- clean up database schema files

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68736e593e148323a4afa8bfdfe63092