### PR TITLE
Add price list and warehouse selection per order item

### DIFF
--- a/frontend/src/components/ItemConfirmationModal.jsx
+++ b/frontend/src/components/ItemConfirmationModal.jsx
@@ -7,10 +7,16 @@ export default function ItemConfirmationModal({
     onClose,
     onConfirm,
     confirmLabel = "Agregar al Pedido",
+    priceLists = [],
+    warehouses = [],
+    defaultPriceListId = "",
+    defaultWarehouseId = "",
 }) {
     const [quantity, setQuantity] = useState(1);
     const [price, setPrice] = useState(0);
     const [subtotal, setSubtotal] = useState(0);
+    const [priceListId, setPriceListId] = useState(defaultPriceListId);
+    const [warehouseId, setWarehouseId] = useState(defaultWarehouseId);
 
     useEffect(() => {
         if (item) {
@@ -19,6 +25,11 @@ export default function ItemConfirmationModal({
             setQuantity(item.quantity || 1);
         }
     }, [item]);
+
+    useEffect(() => {
+        setPriceListId(defaultPriceListId || "");
+        setWarehouseId(defaultWarehouseId || "");
+    }, [defaultPriceListId, defaultWarehouseId]);
 
     useEffect(() => {
         setSubtotal(quantity * price);
@@ -47,6 +58,8 @@ export default function ItemConfirmationModal({
             description: item.description,
             quantity: parseInt(quantity, 10),
             price: parseFloat(price),
+            priceListId: priceListId ? parseInt(priceListId) : null,
+            warehouseId: warehouseId ? parseInt(warehouseId) : null,
         };
 
         console.log("ItemConfirmationModal - Item a confirmar:", itemWithDetails); // Debug log
@@ -162,6 +175,42 @@ export default function ItemConfirmationModal({
                                 step="0.01"
                                 className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                             />
+                        </div>
+                        <div>
+                            <label htmlFor="priceListId" className="block text-sm font-medium text-gray-700 mb-1">
+                                Lista de Precios
+                            </label>
+                            <select
+                                id="priceListId"
+                                value={priceListId}
+                                onChange={(e) => setPriceListId(e.target.value)}
+                                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                            >
+                                <option value="">Seleccionar...</option>
+                                {priceLists.map((pl) => (
+                                    <option key={pl.PriceListID} value={pl.PriceListID}>
+                                        {pl.Name}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                        <div>
+                            <label htmlFor="warehouseId" className="block text-sm font-medium text-gray-700 mb-1">
+                                Depósito
+                            </label>
+                            <select
+                                id="warehouseId"
+                                value={warehouseId}
+                                onChange={(e) => setWarehouseId(e.target.value)}
+                                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                            >
+                                <option value="">Seleccionar...</option>
+                                {warehouses.map((w) => (
+                                    <option key={w.WarehouseID} value={w.WarehouseID}>
+                                        {w.Name}
+                                    </option>
+                                ))}
+                            </select>
                         </div>
                     </div>
 

--- a/frontend/src/pages/OrderCreate.jsx
+++ b/frontend/src/pages/OrderCreate.jsx
@@ -103,6 +103,8 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
                         description: d.Description || "",
                         quantity: d.Quantity,
                         price: d.UnitPrice,
+                        priceListId: d.PriceListID,
+                        warehouseId: d.WarehouseID,
                         subtotal: d.Quantity * d.UnitPrice,
                         orderSessionID: d.OrderSessionID,
                     }));
@@ -195,7 +197,11 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
     };
 
     const handleItemSelectedFromSearch = (selectedItem) => {
-        setSelectedItemForConfirmation(selectedItem);
+        setSelectedItemForConfirmation({
+            ...selectedItem,
+            priceListId: formData.priceListId,
+            warehouseId: formData.warehouseId,
+        });
         setShowItemSearchModal(false);
         setShowItemConfirmationModal(true);
         setEditIndex(null);
@@ -208,6 +214,12 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
             Quantity: parseInt(itemWithDetails.quantity),
             UnitPrice: parseFloat(itemWithDetails.price),
             Description: itemWithDetails.description || "",
+            WarehouseID: itemWithDetails.warehouseId
+                ? parseInt(itemWithDetails.warehouseId)
+                : parseInt(formData.warehouseId),
+            PriceListID: itemWithDetails.priceListId
+                ? parseInt(itemWithDetails.priceListId)
+                : parseInt(formData.priceListId),
         };
 
         if (editIndex !== null) {
@@ -217,6 +229,8 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
                 ...existing,
                 quantity: itemWithDetails.quantity,
                 price: itemWithDetails.price,
+                priceListId: baseData.PriceListID,
+                warehouseId: baseData.WarehouseID,
                 subtotal: itemWithDetails.quantity * itemWithDetails.price,
             };
             setItems(updatedItems);
@@ -238,9 +252,11 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
                 BranchID: parseInt(formData.branchId),
                 UserID: parseInt(formData.userId),
                 ItemID: parseInt(itemWithDetails.itemID),
-                WarehouseID: parseInt(formData.warehouseId),
-                PriceListID: parseInt(formData.priceListId),
-                ...baseData,
+                WarehouseID: baseData.WarehouseID,
+                PriceListID: baseData.PriceListID,
+                Quantity: baseData.Quantity,
+                UnitPrice: baseData.UnitPrice,
+                Description: baseData.Description,
             };
             if (sessionId) {
                 tempData.OrderSessionID = sessionId;
@@ -255,6 +271,8 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
                     description: itemWithDetails.description,
                     quantity: itemWithDetails.quantity,
                     price: itemWithDetails.price,
+                    priceListId: baseData.PriceListID,
+                    warehouseId: baseData.WarehouseID,
                     subtotal: itemWithDetails.quantity * itemWithDetails.price,
                     orderSessionID: tempItem.OrderSessionID,
                 };
@@ -292,6 +310,8 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
             description: item.description,
             quantity: item.quantity,
             price: item.price,
+            priceListId: item.priceListId || formData.priceListId,
+            warehouseId: item.warehouseId || formData.warehouseId,
         });
         setEditIndex(index);
         setShowItemConfirmationModal(true);
@@ -378,7 +398,7 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
             WarehouseID: parseInt(finalFormData.warehouseId),
             Items: items.map((item) => ({
                 ItemID: parseInt(item.itemID),
-                WarehouseID: parseInt(finalFormData.warehouseId),
+                WarehouseID: parseInt(item.warehouseId || finalFormData.warehouseId),
                 Quantity: parseInt(item.quantity),
                 UnitPrice: parseFloat(item.price),
                 Description: item.description || null,
@@ -988,8 +1008,13 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
                     }}
                     onConfirm={handleItemConfirmed}
                     confirmLabel={editIndex !== null ? "Actualizar Ítem" : "Agregar al Pedido"}
+                    priceLists={priceLists}
+                    warehouses={warehouses}
+                    defaultPriceListId={selectedItemForConfirmation.priceListId || formData.priceListId}
+                    defaultWarehouseId={selectedItemForConfirmation.warehouseId || formData.warehouseId}
                 />
             )}
         </div>
     );
+
 }


### PR DESCRIPTION
## Summary
- extend `ItemConfirmationModal` to allow selecting price list and warehouse
- store the selected IDs when adding/editing items in `OrderCreate`
- default selections use order's price list and warehouse
- pass selected IDs to temporary order details

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-refresh')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687381c6e5688323b5fa2a431c41d36a