### PR TITLE
Add cancel handling for order creation

### DIFF
--- a/frontend/src/pages/OrderCreate.jsx
+++ b/frontend/src/pages/OrderCreate.jsx
@@ -317,6 +317,18 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
         setShowItemConfirmationModal(true);
     };
 
+    const handleCancel = async () => {
+        try {
+            if (sessionId) {
+                await tempOrderOperations.clearTempSession(sessionId);
+            }
+        } catch (err) {
+            console.error("Error limpiando items temporales:", err);
+        } finally {
+            onClose && onClose();
+        }
+    };
+
     const handleSubmit = async (e) => {
         e.preventDefault();
 
@@ -476,6 +488,21 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
             total: sub + vatAmount,
         }));
     }, [items]);
+
+    useEffect(() => {
+        const cleanup = () => {
+            if (sessionId) {
+                tempOrderOperations.clearTempSession(sessionId).catch((err) => {
+                    console.error("Error limpiando items temporales:", err);
+                });
+            }
+        };
+        window.addEventListener("beforeunload", cleanup);
+        return () => {
+            window.removeEventListener("beforeunload", cleanup);
+            cleanup();
+        };
+    }, [sessionId]);
 
     return (
         <div className="container mx-auto p-4 md:p-6 bg-gray-100 min-h-screen">
@@ -952,12 +979,28 @@ export default function OrderCreate({ onClose, onSave, order: initialOrder = nul
                             </p>
                         </div>
 
-                        <button
-                            type="submit"
-                            className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-3 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition ease-in-out duration-150 text-lg"
-                        >
-                            {isEdit ? 'Guardar Cambios' : 'Guardar Pedido'}
-                        </button>
+                        <div className="flex justify-end space-x-4 pt-4 border-t">
+                            <button
+                                type="button"
+                                onClick={handleCancel}
+                                className="px-4 py-2 border border-gray-300 rounded hover:bg-gray-50"
+                            >
+                                Cancelar
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => {}}
+                                className="px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600"
+                            >
+                                Emitir
+                            </button>
+                            <button
+                                type="submit"
+                                className="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+                            >
+                                {isEdit ? 'Guardar Cambios' : 'Guardar Pedido'}
+                            </button>
+                        </div>
                     </section>
                 </form>
             </div>

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -637,6 +637,11 @@ export const MUTATIONS = {
             deleteTemporderdetail(sessionID: $sessionID, itemID: $itemID)
         }
     `,
+    CLEAR_TEMP_SESSION: `
+        mutation ClearTempSession($sessionID: String!) {
+            clearTempSession(sessionID: $sessionID)
+        }
+    `,
 
     LOAD_ORDER_FOR_EDITING: `
         mutation LoadOrderForEditing($orderID: Int!, $userID: Int!, $companyID: Int!, $branchID: Int!) {

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1268,6 +1268,18 @@ export const tempOrderOperations = {
         }
     },
 
+    async clearTempSession(sessionID) {
+        try {
+            await graphqlClient.mutation(MUTATIONS.CLEAR_TEMP_SESSION, {
+                sessionID,
+            });
+            return true;
+        } catch (error) {
+            console.error("Error limpiando sesión temporal:", error);
+            throw error;
+        }
+    },
+
     async loadOrderForEditing(orderID, userID, companyID, branchID) {
         try {
             const result = await graphqlClient.mutation(


### PR DESCRIPTION
## Summary
- allow clearing temp order data
- add mutation to clear temporary order details by session
- add cancel and emit buttons to order page
- remove temp data when window closes or cancel pressed

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68738ac8e76c832392ea6fa0981326d1