### PR TITLE
Fix duplicated temp order items

### DIFF
--- a/app/graphql/crud/temporderdetails.py
+++ b/app/graphql/crud/temporderdetails.py
@@ -146,6 +146,17 @@ def delete_temporderdetails_by_session(
     return count
 
 
+def delete_temporderdetails_by_order(db: Session, order_id: int) -> int:
+    """Eliminar todos los TempOrderDetails asociados a una orden."""
+    count = (
+        db.query(TempOrderDetails)
+        .filter(TempOrderDetails.OrderID == order_id)
+        .delete(synchronize_session=False)
+    )
+    db.commit()
+    return count
+
+
 def load_orderdetails_to_temp(
     db: Session, order_id: int, user_id: int, company_id: int, branch_id: int
 ) -> str:
@@ -154,7 +165,10 @@ def load_orderdetails_to_temp(
     Retorna el OrderSessionID generado
     """
     from app.models.orderdetails import OrderDetails
-    
+
+    # Limpiar cualquier sesión previa asociada a esta orden
+    delete_temporderdetails_by_order(db, order_id)
+
     # Generar nuevo session ID para la edición
     session_id = uuid4()
     


### PR DESCRIPTION
## Summary
- ensure previous TempOrderDetails for an order are removed when starting an edit session
- add helper function to delete temp items by order

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6873960ec3048323bd16f1395436e68d