### PR TITLE
Add discounts listing & CRUD

### DIFF
--- a/app/graphql/mutations/discounts.py
+++ b/app/graphql/mutations/discounts.py
@@ -1,0 +1,49 @@
+# app/graphql/mutations/discounts.py
+import strawberry
+from typing import Optional
+from app.graphql.schemas.discounts import (
+    DiscountsCreate,
+    DiscountsUpdate,
+    DiscountsInDB,
+)
+from app.graphql.crud.discounts import (
+    create_discounts,
+    update_discounts,
+    delete_discounts,
+)
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+
+@strawberry.type
+class DiscountsMutations:
+    @strawberry.mutation
+    def create_discount(self, info: Info, data: DiscountsCreate) -> DiscountsInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            obj = create_discounts(db, data)
+            return obj_to_schema(DiscountsInDB, obj)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_discount(self, info: Info, id: int, data: DiscountsUpdate) -> Optional[DiscountsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated = update_discounts(db, id, data)
+            return obj_to_schema(DiscountsInDB, updated) if updated else None
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_discount(self, info: Info, id: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_discounts(db, id)
+            return deleted is not None
+        finally:
+            db_gen.close()

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -59,6 +59,7 @@ from app.graphql.mutations.items import ItemsMutations
 from app.graphql.mutations.saleconditions import SaleConditionsMutations
 from app.graphql.mutations.creditcardgroups import CreditCardGroupsMutations
 from app.graphql.mutations.creditcards import CreditCardsMutations
+from app.graphql.mutations.discounts import DiscountsMutations
 from app.graphql.mutations.carmodels import CarModelsMutations
 from app.graphql.mutations.cars import CarsMutations
 from app.graphql.mutations.branches import BranchesMutations
@@ -407,6 +408,7 @@ class Mutation(
     SaleConditionsMutations,
     CreditCardGroupsMutations,
     CreditCardsMutations,
+    DiscountsMutations,
     BranchesMutations,
     CompanydataMutations,
     WarehousesMutations,

--- a/app/graphql/schemas/discounts.py
+++ b/app/graphql/schemas/discounts.py
@@ -9,7 +9,7 @@ class DiscountsCreate:
 @strawberry.input
 class DiscountsUpdate:
     DiscountName: str
-    Oercentage: float
+    Percentage: float
 
 @strawberry.type
 class DiscountsInDB:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ import Warehouses from "./pages/Warehouses";
 import SaleConditions from "./pages/SaleConditions";
 import CreditCardGroups from "./pages/CreditCardGroups";
 import CreditCards from "./pages/CreditCards";
+import Discounts from "./pages/Discounts";
 import Documents from "./pages/Documents";
 import Orders from "./pages/Orders";
 import Roles from "./pages/Roles";
@@ -201,6 +202,7 @@ export default function App() {
                     <Route path="saleconditions" element={<SaleConditions />} />
                     <Route path="creditcardgroups" element={<CreditCardGroups />} />
                     <Route path="creditcards" element={<CreditCards />} />
+                    <Route path="discounts" element={<Discounts />} />
                     <Route path="itemcategories" element={<ItemCategories />} />
                     <Route path="itemsubcategories" element={<ItemSubcategories />} />
                     <Route path="items" element={<Items />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -78,6 +78,7 @@ export default function Sidebar() {
                     submenu: [
                         { label: "Grupos Tarjetas", to: "/creditcardgroups" },
                         { label: "Tarjetas", to: "/creditcards" },
+                        { label: "Descuentos", to: "/discounts" },
                         { label: "Condiciones", to: "/saleconditions" },
                     ],
                 },

--- a/frontend/src/pages/DiscountCreate.jsx
+++ b/frontend/src/pages/DiscountCreate.jsx
@@ -1,0 +1,93 @@
+// frontend/src/pages/DiscountCreate.jsx
+import { useState, useEffect } from "react";
+import { discountOperations } from "../utils/graphqlClient";
+
+export default function DiscountCreate({ onClose, onSave, discount: initialDiscount = null }) {
+    const [discountName, setDiscountName] = useState("");
+    const [percentage, setPercentage] = useState(0);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [isEdit, setIsEdit] = useState(false);
+
+    useEffect(() => {
+        if (initialDiscount) {
+            setIsEdit(true);
+            setDiscountName(initialDiscount.DiscountName || "");
+            setPercentage(initialDiscount.Percentage || 0);
+        }
+    }, [initialDiscount]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            let result;
+            if (isEdit) {
+                result = await discountOperations.updateDiscount(initialDiscount.DiscountID, {
+                    DiscountName: discountName,
+                    Percentage: parseFloat(percentage)
+                });
+            } else {
+                result = await discountOperations.createDiscount({
+                    DiscountName: discountName,
+                    Percentage: parseFloat(percentage)
+                });
+            }
+            onSave && onSave(result);
+            onClose && onClose();
+        } catch (err) {
+            console.error("Error guardando descuento:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Descuento' : 'Nuevo Descuento'}</h2>
+            {error && <div className="text-red-600 mb-2">{error}</div>}
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-1">Nombre</label>
+                    <input
+                        type="text"
+                        value={discountName}
+                        onChange={(e) => setDiscountName(e.target.value)}
+                        className="w-full border border-gray-300 p-2 rounded"
+                        required
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Porcentaje</label>
+                    <input
+                        type="number"
+                        value={percentage}
+                        onChange={(e) => setPercentage(e.target.value)}
+                        className="w-full border border-gray-300 p-2 rounded"
+                        step="0.01"
+                        required
+                    />
+                </div>
+                <div className="flex justify-end space-x-4 pt-4 border-t">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        disabled={loading}
+                        className="px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+                    >
+                        Cancelar
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={loading || !discountName.trim()}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                        {loading ? 'Guardando...' : 'Guardar'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/pages/Discounts.jsx
+++ b/frontend/src/pages/Discounts.jsx
@@ -1,0 +1,136 @@
+// frontend/src/pages/Discounts.jsx
+import { useEffect, useState } from "react";
+import { discountOperations } from "../utils/graphqlClient";
+import DiscountCreate from "./DiscountCreate";
+import TableFilters from "../components/TableFilters";
+import { openReactWindow } from "../utils/openReactWindow";
+
+export default function Discounts() {
+    const [allDiscounts, setAllDiscounts] = useState([]);
+    const [discounts, setDiscounts] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
+
+    useEffect(() => { loadDiscounts(); }, []);
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-discounts') {
+                loadDiscounts();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
+    }, []);
+
+    const loadDiscounts = async () => {
+        try {
+            setLoading(true);
+            const data = await discountOperations.getAllDiscounts();
+            setAllDiscounts(data);
+            setDiscounts(data);
+        } catch (err) {
+            setError(err.message);
+            setDiscounts([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleCreate = () => {
+        openReactWindow(
+            (popup) => (
+                <DiscountCreate
+                    onSave={() => {
+                        popup.opener.postMessage('reload-discounts', '*');
+                        popup.close();
+                    }}
+                    onClose={() => popup.close()}
+                />
+            ),
+            'Nuevo Descuento'
+        );
+    };
+
+    const handleFilterChange = (filtered) => {
+        setDiscounts(filtered);
+    };
+
+    const handleEdit = (discount) => {
+        openReactWindow(
+            (popup) => (
+                <DiscountCreate
+                    discount={discount}
+                    onSave={() => {
+                        popup.opener.postMessage('reload-discounts', '*');
+                        popup.close();
+                    }}
+                    onClose={() => popup.close()}
+                />
+            ),
+            'Editar Descuento'
+        );
+    };
+
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar descuento?')) return;
+        try {
+            await discountOperations.deleteDiscount(id);
+            loadDiscounts();
+        } catch (err) {
+            alert('Error al borrar descuento: ' + err.message);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold text-gray-800">Descuentos</h1>
+                <div className="flex space-x-2">
+                    <button
+                        onClick={() => setShowFilters(!showFilters)}
+                        className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700"
+                    >
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button
+                        onClick={loadDiscounts}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                    >
+                        Recargar
+                    </button>
+                    <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                        Nuevo Descuento
+                    </button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters
+                        modelName="discounts"
+                        data={allDiscounts}
+                        onFilterChange={handleFilterChange}
+                    />
+                </div>
+            )}
+            {error && <div className="text-red-600 mb-4">{error}</div>}
+            {loading ? (
+                <div>Cargando...</div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {discounts.map(d => (
+                        <div key={d.DiscountID} className="bg-white rounded shadow p-4">
+                            <h3 className="text-lg font-semibold mb-2">{d.DiscountName}</h3>
+                            <p className="text-sm mb-1">Porcentaje: {d.Percentage}%</p>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(d)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(d.DiscountID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -361,6 +361,31 @@ export const MUTATIONS = {
         }
     `,
 
+    // DESCUENTOS
+    CREATE_DISCOUNT: `
+        mutation CreateDiscount($input: DiscountsCreate!) {
+            createDiscount(data: $input) {
+                DiscountID
+                DiscountName
+                Percentage
+            }
+        }
+    `,
+    UPDATE_DISCOUNT: `
+        mutation UpdateDiscount($id: Int!, $input: DiscountsUpdate!) {
+            updateDiscount(id: $id, data: $input) {
+                DiscountID
+                DiscountName
+                Percentage
+            }
+        }
+    `,
+    DELETE_DISCOUNT: `
+        mutation DeleteDiscount($id: Int!) {
+            deleteDiscount(id: $id)
+        }
+    `,
+
     // CONDICIONES DE VENTA
     CREATE_SALECONDITION: `
         mutation CreateSaleCondition($input: SaleConditionsCreate!) {

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -678,6 +678,51 @@ export const discountOperations = {
             console.error("Error obteniendo descuentos:", error);
             throw error;
         }
+    },
+
+    async getDiscountById(id) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_DISCOUNT_BY_ID, { id });
+            return data.discountsById;
+        } catch (error) {
+            console.error("Error obteniendo descuento:", error);
+            throw error;
+        }
+    },
+
+    async createDiscount(discountData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.CREATE_DISCOUNT, {
+                input: discountData
+            });
+            return data.createDiscount;
+        } catch (error) {
+            console.error("Error creando descuento:", error);
+            throw error;
+        }
+    },
+
+    async updateDiscount(id, discountData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_DISCOUNT, {
+                id,
+                input: discountData
+            });
+            return data.updateDiscount;
+        } catch (error) {
+            console.error("Error actualizando descuento:", error);
+            throw error;
+        }
+    },
+
+    async deleteDiscount(id) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.DELETE_DISCOUNT, { id });
+            return data.deleteDiscount;
+        } catch (error) {
+            console.error("Error eliminando descuento:", error);
+            throw error;
+        }
     }
 };
 

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -646,6 +646,15 @@ export const QUERIES = {
             }
         }
     `,
+    GET_DISCOUNT_BY_ID: `
+        query GetDiscountById($id: Int!) {
+            discountsById(id: $id) {
+                DiscountID
+                DiscountName
+                Percentage
+            }
+        }
+    `,
 
     // GRUPOS DE TARJETAS DE CRÉDITO
     GET_ALL_CREDITCARDGROUPS: `


### PR DESCRIPTION
## Summary
- add GraphQL schema, mutations and operations for Discounts
- expose discount management routes and pages in the frontend
- enable Discounts submenu item in sidebar
- include route for discounts in App router

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687b303a2d6883239ef01d594cb8e56a