### PR TITLE
Add documents management

### DIFF
--- a/app/graphql/mutations/documents.py
+++ b/app/graphql/mutations/documents.py
@@ -1,0 +1,46 @@
+# app/graphql/mutations/documents.py
+import strawberry
+from typing import Optional
+from app.graphql.schemas.documents import DocumentsCreate, DocumentsUpdate, DocumentsInDB
+from app.graphql.crud.documents import create_documents, update_documents, delete_documents
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+from app.graphql.schemas.delete_response import DeleteResponse
+
+@strawberry.type
+class DocumentsMutations:
+    @strawberry.mutation
+    def create_document(self, info: Info, data: DocumentsCreate) -> DocumentsInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            obj = create_documents(db, data)
+            return obj_to_schema(DocumentsInDB, obj)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_document(self, info: Info, documentID: int, data: DocumentsUpdate) -> Optional[DocumentsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated = update_documents(db, documentID, data)
+            return obj_to_schema(DocumentsInDB, updated) if updated else None
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_document(self, info: Info, documentID: int) -> DeleteResponse:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_documents(db, documentID)
+            success = deleted is not None
+            message = "Document deleted" if success else "Document not found"
+            return DeleteResponse(success=success, message=message)
+        except ValueError as e:
+            db.rollback()
+            return DeleteResponse(success=False, message=str(e))
+        finally:
+            db_gen.close()

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -70,6 +70,7 @@ from app.graphql.mutations.temporderdetails import TempOrderDetailsMutations
 from app.graphql.mutations.orders import OrdersMutations
 from app.graphql.mutations.servicetype import ServiceTypeMutations
 from app.graphql.mutations.documenttypes import DocumentTypesMutations
+from app.graphql.mutations.documents import DocumentsMutations
 from app.graphql.mutations.useractions import UserActionsMutations
 from app.graphql.mutations.roles import RolesMutations
 from app.graphql.mutations.users import UsersMutations
@@ -416,6 +417,7 @@ class Mutation(
     TempOrderDetailsMutations,
     OrdersMutations,
     ServiceTypeMutations,
+    DocumentsMutations,
     DocumentTypesMutations,
     UserActionsMutations,
     RolesMutations,

--- a/app/utils/filter_schemas.py
+++ b/app/utils/filter_schemas.py
@@ -244,5 +244,24 @@ FILTER_SCHEMAS = {
         {"field": "ItemDescription", "label": "Descripción ítem", "type": "text"},
         {"field": "Price", "label": "Precio", "type": "number"},
         {"field": "LastModified", "label": "Última modificación", "type": "text"}
+    ],
+
+    "documents": [
+        {"field": "DocumentID", "label": "ID de documento", "type": "number"},
+        {"field": "CompanyID", "label": "Compañía", "type": "select", "relationModel": "Company"},
+        {"field": "BranchID", "label": "Sucursal", "type": "select", "relationModel": "Branch"},
+        {"field": "DocumentTypeID", "label": "Tipo de documento", "type": "select", "relationModel": "DocType"},
+        {"field": "Description", "label": "Descripción", "type": "text"},
+        {"field": "DocumentNumber", "label": "Número", "type": "number"},
+        {"field": "PointOfSale", "label": "Punto de venta", "type": "number"},
+        {"field": "IsActive", "label": "Activo", "type": "boolean"},
+        {"field": "Testing", "label": "Prueba", "type": "boolean"},
+        {"field": "ShouldAccount", "label": "Contabiliza", "type": "boolean"},
+        {"field": "MovesStock", "label": "Mueve stock", "type": "boolean"},
+        {"field": "IsFiscal", "label": "Fiscal", "type": "boolean"},
+        {"field": "IsElectronic", "label": "Electrónico", "type": "boolean"},
+        {"field": "IsManual", "label": "Manual", "type": "boolean"},
+        {"field": "IsQuotation", "label": "Cotización", "type": "boolean"},
+        {"field": "MaxItems", "label": "Máx ítems", "type": "number"}
     ]
 }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -80,6 +80,7 @@ export default function Sidebar() {
                         { label: "Tarjetas", to: "/creditcards" },
                         { label: "Descuentos", to: "/discounts" },
                         { label: "Condiciones", to: "/saleconditions" },
+                        { label: "Documentos", to: "/documents" },
                     ],
                 },
                 {

--- a/frontend/src/pages/DocumentCreate.jsx
+++ b/frontend/src/pages/DocumentCreate.jsx
@@ -1,0 +1,167 @@
+// frontend/src/pages/DocumentCreate.jsx
+import { useState, useEffect } from "react";
+import { documentOperations, companyOperations, branchOperations, documentTypeOperations } from "../utils/graphqlClient";
+
+export default function DocumentCreate({ onClose, onSave, document: initialDoc = null }) {
+    const [companies, setCompanies] = useState([]);
+    const [branches, setBranches] = useState([]);
+    const [docTypes, setDocTypes] = useState([]);
+
+    const [companyID, setCompanyID] = useState("");
+    const [branchID, setBranchID] = useState("");
+    const [documentTypeID, setDocumentTypeID] = useState("");
+    const [description, setDescription] = useState("");
+    const [documentNumber, setDocumentNumber] = useState("");
+    const [pointOfSale, setPointOfSale] = useState("");
+    const [isActive, setIsActive] = useState(true);
+    const [testing, setTesting] = useState(false);
+    const [shouldAccount, setShouldAccount] = useState(false);
+    const [movesStock, setMovesStock] = useState(false);
+    const [isFiscal, setIsFiscal] = useState(false);
+    const [isElectronic, setIsElectronic] = useState(false);
+    const [isManual, setIsManual] = useState(false);
+    const [isQuotation, setIsQuotation] = useState(false);
+    const [maxItems, setMaxItems] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [isEdit, setIsEdit] = useState(false);
+
+    useEffect(() => {
+        async function loadData() {
+            try {
+                const [comp, br, types] = await Promise.all([
+                    companyOperations.getAllCompanies(),
+                    branchOperations.getAllBranches(),
+                    documentTypeOperations.getAllDocumenttypes(),
+                ]);
+                setCompanies(comp);
+                setBranches(br);
+                setDocTypes(types);
+            } catch (err) {
+                console.error("Error cargando datos:", err);
+            }
+        }
+        loadData();
+    }, []);
+
+    useEffect(() => {
+        if (initialDoc) {
+            setIsEdit(true);
+            setCompanyID(initialDoc.CompanyID || "");
+            setBranchID(initialDoc.BranchID || "");
+            setDocumentTypeID(initialDoc.DocumentTypeID || "");
+            setDescription(initialDoc.Description || "");
+            setDocumentNumber(initialDoc.DocumentNumber || "");
+            setPointOfSale(initialDoc.PointOfSale || "");
+            setIsActive(initialDoc.IsActive !== false);
+            setTesting(initialDoc.Testing || false);
+            setShouldAccount(initialDoc.ShouldAccount || false);
+            setMovesStock(initialDoc.MovesStock || false);
+            setIsFiscal(initialDoc.IsFiscal || false);
+            setIsElectronic(initialDoc.IsElectronic || false);
+            setIsManual(initialDoc.IsManual || false);
+            setIsQuotation(initialDoc.IsQuotation || false);
+            setMaxItems(initialDoc.MaxItems || "");
+        }
+    }, [initialDoc]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            const payload = {
+                CompanyID: parseInt(companyID),
+                BranchID: parseInt(branchID),
+                DocumentTypeID: parseInt(documentTypeID),
+                Description: description,
+                DocumentNumber: documentNumber ? parseInt(documentNumber) : null,
+                PointOfSale: pointOfSale ? parseInt(pointOfSale) : null,
+                IsActive: isActive,
+                Testing: testing,
+                ShouldAccount: shouldAccount,
+                MovesStock: movesStock,
+                IsFiscal: isFiscal,
+                IsElectronic: isElectronic,
+                IsManual: isManual,
+                IsQuotation: isQuotation,
+                MaxItems: maxItems ? parseInt(maxItems) : null,
+            };
+            let result;
+            if (isEdit) {
+                result = await documentOperations.updateDocument(initialDoc.DocumentID, payload);
+            } else {
+                result = await documentOperations.createDocument(payload);
+            }
+            onSave && onSave(result);
+            onClose && onClose();
+        } catch (err) {
+            console.error("Error guardando documento:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="p-6 overflow-y-auto h-full">
+            <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Documento' : 'Nuevo Documento'}</h2>
+            {error && <div className="text-red-600 mb-2">{error}</div>}
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-1">Compañía</label>
+                    <select value={companyID} onChange={e => setCompanyID(e.target.value)} className="w-full border p-2 rounded" required>
+                        <option value="">Seleccione</option>
+                        {companies.map(c => <option key={c.CompanyID} value={c.CompanyID}>{c.Name}</option>)}
+                    </select>
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Sucursal</label>
+                    <select value={branchID} onChange={e => setBranchID(e.target.value)} className="w-full border p-2 rounded" required>
+                        <option value="">Seleccione</option>
+                        {branches.map(b => <option key={b.BranchID} value={b.BranchID}>{b.Name}</option>)}
+                    </select>
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Tipo de Documento</label>
+                    <select value={documentTypeID} onChange={e => setDocumentTypeID(e.target.value)} className="w-full border p-2 rounded" required>
+                        <option value="">Seleccione</option>
+                        {docTypes.map(dt => <option key={dt.DocTypeID} value={dt.DocTypeID}>{dt.Name}</option>)}
+                    </select>
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Descripción</label>
+                    <input type="text" value={description} onChange={e => setDescription(e.target.value)} className="w-full border p-2 rounded" />
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label className="block text-sm font-medium mb-1">Número</label>
+                        <input type="number" value={documentNumber} onChange={e => setDocumentNumber(e.target.value)} className="w-full border p-2 rounded" />
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium mb-1">Punto de venta</label>
+                        <input type="number" value={pointOfSale} onChange={e => setPointOfSale(e.target.value)} className="w-full border p-2 rounded" />
+                    </div>
+                </div>
+                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                    <label className="inline-flex items-center"><input type="checkbox" className="mr-2" checked={isActive} onChange={e => setIsActive(e.target.checked)} />Activo</label>
+                    <label className="inline-flex items-center"><input type="checkbox" className="mr-2" checked={testing} onChange={e => setTesting(e.target.checked)} />Prueba</label>
+                    <label className="inline-flex items-center"><input type="checkbox" className="mr-2" checked={shouldAccount} onChange={e => setShouldAccount(e.target.checked)} />Contabiliza</label>
+                    <label className="inline-flex items-center"><input type="checkbox" className="mr-2" checked={movesStock} onChange={e => setMovesStock(e.target.checked)} />Mueve stock</label>
+                    <label className="inline-flex items-center"><input type="checkbox" className="mr-2" checked={isFiscal} onChange={e => setIsFiscal(e.target.checked)} />Fiscal</label>
+                    <label className="inline-flex items-center"><input type="checkbox" className="mr-2" checked={isElectronic} onChange={e => setIsElectronic(e.target.checked)} />Electrónico</label>
+                    <label className="inline-flex items-center"><input type="checkbox" className="mr-2" checked={isManual} onChange={e => setIsManual(e.target.checked)} />Manual</label>
+                    <label className="inline-flex items-center"><input type="checkbox" className="mr-2" checked={isQuotation} onChange={e => setIsQuotation(e.target.checked)} />Cotización</label>
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Máx ítems</label>
+                    <input type="number" value={maxItems} onChange={e => setMaxItems(e.target.value)} className="w-full border p-2 rounded" />
+                </div>
+                <div className="flex justify-end space-x-4 pt-4 border-t">
+                    <button type="button" onClick={onClose} disabled={loading} className="px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50">Cancelar</button>
+                    <button type="submit" disabled={loading || !companyID || !branchID || !documentTypeID} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">{loading ? 'Guardando...' : 'Guardar'}</button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/pages/Documents.jsx
+++ b/frontend/src/pages/Documents.jsx
@@ -1,11 +1,149 @@
-// src/pages/Documents.jsx
-import React from "react";
+// frontend/src/pages/Documents.jsx
+import { useEffect, useState } from "react";
+import { documentOperations, companyOperations, branchOperations, documentTypeOperations } from "../utils/graphqlClient";
+import DocumentCreate from "./DocumentCreate";
+import TableFilters from "../components/TableFilters";
+import { openReactWindow } from "../utils/openReactWindow";
 
 export default function Documents() {
-  return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">Comprobantes</h1>
-      <p>Aquí irá la gestión de comprobantes (Documents).</p>
-    </div>
-  );
+    const [allDocs, setAllDocs] = useState([]);
+    const [documents, setDocuments] = useState([]);
+    const [companies, setCompanies] = useState([]);
+    const [branches, setBranches] = useState([]);
+    const [docTypes, setDocTypes] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
+
+    useEffect(() => { loadDocuments(); }, []);
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-documents') {
+                loadDocuments();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
+    }, []);
+
+    const loadDocuments = async () => {
+        try {
+            setLoading(true);
+            const [docs, comps, brs, types] = await Promise.all([
+                documentOperations.getAllDocuments(),
+                companyOperations.getAllCompanies(),
+                branchOperations.getAllBranches(),
+                documentTypeOperations.getAllDocumenttypes(),
+            ]);
+            setAllDocs(docs);
+            setDocuments(docs);
+            setCompanies(comps);
+            setBranches(brs);
+            setDocTypes(types);
+        } catch (err) {
+            console.error("Error cargando documentos:", err);
+            setError(err.message);
+            setDocuments([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleCreate = () => {
+        openReactWindow(
+            (popup) => (
+                <DocumentCreate
+                    companies={companies}
+                    branches={branches}
+                    docTypes={docTypes}
+                    onSave={() => {
+                        popup.opener.postMessage('reload-documents', '*');
+                        popup.close();
+                    }}
+                    onClose={() => popup.close()}
+                />
+            ),
+            'Nuevo Documento'
+        );
+    };
+
+    const handleFilterChange = (filtered) => setDocuments(filtered);
+
+    const handleEdit = (doc) => {
+        openReactWindow(
+            (popup) => (
+                <DocumentCreate
+                    document={doc}
+                    companies={companies}
+                    branches={branches}
+                    docTypes={docTypes}
+                    onSave={() => {
+                        popup.opener.postMessage('reload-documents', '*');
+                        popup.close();
+                    }}
+                    onClose={() => popup.close()}
+                />
+            ),
+            'Editar Documento'
+        );
+    };
+
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar documento?')) return;
+        try {
+            await documentOperations.deleteDocument(id);
+            loadDocuments();
+        } catch (err) {
+            alert('Error al borrar documento: ' + err.message);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold text-gray-800">Documentos</h1>
+                <div className="flex space-x-2">
+                    <button onClick={() => setShowFilters(!showFilters)} className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700">
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button onClick={loadDocuments} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                        Recargar
+                    </button>
+                    <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                        Nuevo Documento
+                    </button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters modelName="documents" data={allDocs} onFilterChange={handleFilterChange} />
+                </div>
+            )}
+            {error && <div className="text-red-600 mb-4">{error}</div>}
+            {loading ? (
+                <div>Cargando...</div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {documents.map(doc => {
+                        const comp = companies.find(c => c.CompanyID === doc.CompanyID);
+                        const br = branches.find(b => b.BranchID === doc.BranchID);
+                        const type = docTypes.find(t => t.DocTypeID === doc.DocumentTypeID);
+                        return (
+                            <div key={doc.DocumentID} className="bg-white rounded shadow p-4">
+                                <h3 className="text-lg font-semibold mb-2">{doc.Description}</h3>
+                                <p className="text-sm">{type ? type.Name : doc.DocumentTypeID}</p>
+                                <p className="text-sm">{comp ? comp.Name : doc.CompanyID} - {br ? br.Name : doc.BranchID}</p>
+                                <p className="text-sm mb-1">Número: {doc.DocumentNumber || ''} PV: {doc.PointOfSale || ''}</p>
+                                <div className="flex space-x-2">
+                                    <button onClick={() => handleEdit(doc)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                    <button onClick={() => handleDelete(doc.DocumentID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
 }

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -386,6 +386,60 @@ export const MUTATIONS = {
         }
     `,
 
+    // DOCUMENTOS
+    CREATE_DOCUMENT: `
+        mutation CreateDocument($input: DocumentsCreate!) {
+            createDocument(data: $input) {
+                DocumentID
+                CompanyID
+                BranchID
+                DocumentTypeID
+                Description
+                DocumentNumber
+                PointOfSale
+                IsActive
+                Testing
+                ShouldAccount
+                MovesStock
+                IsFiscal
+                IsElectronic
+                IsManual
+                IsQuotation
+                MaxItems
+            }
+        }
+    `,
+    UPDATE_DOCUMENT: `
+        mutation UpdateDocument($documentID: Int!, $input: DocumentsUpdate!) {
+            updateDocument(documentID: $documentID, data: $input) {
+                DocumentID
+                CompanyID
+                BranchID
+                DocumentTypeID
+                Description
+                DocumentNumber
+                PointOfSale
+                IsActive
+                Testing
+                ShouldAccount
+                MovesStock
+                IsFiscal
+                IsElectronic
+                IsManual
+                IsQuotation
+                MaxItems
+            }
+        }
+    `,
+    DELETE_DOCUMENT: `
+        mutation DeleteDocument($documentID: Int!) {
+            deleteDocument(documentID: $documentID) {
+                success
+                message
+            }
+        }
+    `,
+
     // CONDICIONES DE VENTA
     CREATE_SALECONDITION: `
         mutation CreateSaleCondition($input: SaleConditionsCreate!) {

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -726,6 +726,58 @@ export const discountOperations = {
     }
 };
 
+export const documentOperations = {
+    async getAllDocuments() {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_ALL_DOCUMENTS);
+            return data.allDocuments || [];
+        } catch (error) {
+            console.error("Error obteniendo documentos:", error);
+            throw error;
+        }
+    },
+
+    async getDocumentById(id) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_DOCUMENT_BY_ID, { id });
+            return data.documentsById;
+        } catch (error) {
+            console.error("Error obteniendo documento:", error);
+            throw error;
+        }
+    },
+
+    async createDocument(dataInput) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.CREATE_DOCUMENT, { input: dataInput });
+            return data.createDocument;
+        } catch (error) {
+            console.error("Error creando documento:", error);
+            throw error;
+        }
+    },
+
+    async updateDocument(id, dataInput) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_DOCUMENT, { documentID: id, input: dataInput });
+            return data.updateDocument;
+        } catch (error) {
+            console.error("Error actualizando documento:", error);
+            throw error;
+        }
+    },
+
+    async deleteDocument(id) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.DELETE_DOCUMENT, { documentID: id });
+            return data.deleteDocument;
+        } catch (error) {
+            console.error("Error eliminando documento:", error);
+            throw error;
+        }
+    }
+};
+
 export const saleConditionOperations = {
     async getAllSaleConditions() {
         try {
@@ -1134,6 +1186,13 @@ export const orderStatusOperations = {
     async getAllOrderstatus() {
         const data = await graphqlClient.query(QUERIES.GET_ALL_ORDERSTATUS);
         return data.allOrderstatus || [];
+    }
+};
+
+export const documentTypeOperations = {
+    async getAllDocumenttypes() {
+        const data = await graphqlClient.query(QUERIES.GET_DOCUMENT_TYPES);
+        return data.allDocumenttypes || [];
     }
 };
 

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -810,6 +810,52 @@ export const QUERIES = {
         }
     `,
 
+    // DOCUMENTOS
+    GET_ALL_DOCUMENTS: `
+        query GetAllDocuments {
+            allDocuments {
+                DocumentID
+                CompanyID
+                BranchID
+                DocumentTypeID
+                Description
+                DocumentNumber
+                PointOfSale
+                IsActive
+                Testing
+                ShouldAccount
+                MovesStock
+                IsFiscal
+                IsElectronic
+                IsManual
+                IsQuotation
+                MaxItems
+            }
+        }
+    `,
+    GET_DOCUMENT_BY_ID: `
+        query GetDocumentById($id: Int!) {
+            documentsById(id: $id) {
+                DocumentID
+                CompanyID
+                BranchID
+                DocumentTypeID
+                Description
+                DocumentNumber
+                PointOfSale
+                IsActive
+                Testing
+                ShouldAccount
+                MovesStock
+                IsFiscal
+                IsElectronic
+                IsManual
+                IsQuotation
+                MaxItems
+            }
+        }
+    `,
+
     // BÚSQUEDA DE CLIENTES
     SEARCH_CLIENTS: `
         query SearchClients($searchTerm: String!, $isActive: Boolean) {


### PR DESCRIPTION
## Summary
- add GraphQL queries and mutations for `Documents`
- implement `documentOperations` client helpers
- create `DocumentCreate` form and new `Documents` page with filters
- register `DocumentsMutations` in backend schema
- include new `documents` filter schema
- update sidebar navigation with a link to Documents

## Testing
- `npm run lint`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687b37c6a67c8323935351da0133cc08