### PR TITLE
Add ServiceType module

### DIFF
--- a/app/utils/filter_schemas.py
+++ b/app/utils/filter_schemas.py
@@ -169,6 +169,10 @@ FILTER_SCHEMAS = {
         {"field": "Surcharge", "label": "Recargo", "type": "number"},
         {"field": "IsActive", "label": "Activo", "type": "boolean"}
     ],
+    "servicetypes": [
+        {"field": "ServiceTypeID", "label": "ID de tipo", "type": "number"},
+        {"field": "Type", "label": "Nombre", "type": "text"}
+    ],
     "users": [
         {"field": "UserID", "label": "ID de usuario", "type": "number"},
         {"field": "Nickname", "label": "Usuario", "type": "text"},

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import SaleConditions from "./pages/SaleConditions";
 import CreditCardGroups from "./pages/CreditCardGroups";
 import CreditCards from "./pages/CreditCards";
 import Discounts from "./pages/Discounts";
+import ServiceTypes from "./pages/ServiceTypes";
 import Documents from "./pages/Documents";
 import Orders from "./pages/Orders";
 import Roles from "./pages/Roles";
@@ -203,6 +204,7 @@ export default function App() {
                     <Route path="creditcardgroups" element={<CreditCardGroups />} />
                     <Route path="creditcards" element={<CreditCards />} />
                     <Route path="discounts" element={<Discounts />} />
+                    <Route path="servicetypes" element={<ServiceTypes />} />
                     <Route path="itemcategories" element={<ItemCategories />} />
                     <Route path="itemsubcategories" element={<ItemSubcategories />} />
                     <Route path="items" element={<Items />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -79,6 +79,7 @@ export default function Sidebar() {
                         { label: "Grupos Tarjetas", to: "/creditcardgroups" },
                         { label: "Tarjetas", to: "/creditcards" },
                         { label: "Descuentos", to: "/discounts" },
+                        { label: "Tipos de servicio", to: "/servicetypes" },
                         { label: "Condiciones", to: "/saleconditions" },
                         { label: "Documentos", to: "/documents" },
                     ],

--- a/frontend/src/pages/ServiceTypeCreate.jsx
+++ b/frontend/src/pages/ServiceTypeCreate.jsx
@@ -1,0 +1,74 @@
+// frontend/src/pages/ServiceTypeCreate.jsx
+import { useState, useEffect } from "react";
+import { serviceTypeOperations } from "../utils/graphqlClient";
+
+export default function ServiceTypeCreate({ onClose, onSave, serviceType: initialST = null }) {
+    const [type, setType] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [isEdit, setIsEdit] = useState(false);
+
+    useEffect(() => {
+        if (initialST) {
+            setIsEdit(true);
+            setType(initialST.Type || "");
+        }
+    }, [initialST]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            let result;
+            if (isEdit) {
+                result = await serviceTypeOperations.updateServicetype(initialST.ServiceTypeID, { Type: type });
+            } else {
+                result = await serviceTypeOperations.createServicetype({ Type: type });
+            }
+            onSave && onSave(result);
+            onClose && onClose();
+        } catch (err) {
+            console.error("Error guardando tipo de servicio:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Tipo de Servicio' : 'Nuevo Tipo de Servicio'}</h2>
+            {error && <div className="text-red-600 mb-2">{error}</div>}
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-1">Nombre</label>
+                    <input
+                        type="text"
+                        value={type}
+                        onChange={(e) => setType(e.target.value)}
+                        className="w-full border border-gray-300 p-2 rounded"
+                        required
+                    />
+                </div>
+                <div className="flex justify-end space-x-4 pt-4 border-t">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        disabled={loading}
+                        className="px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+                    >
+                        Cancelar
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={loading || !type.trim()}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                        {loading ? 'Guardando...' : 'Guardar'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/pages/ServiceTypes.jsx
+++ b/frontend/src/pages/ServiceTypes.jsx
@@ -1,0 +1,127 @@
+// frontend/src/pages/ServiceTypes.jsx
+import { useEffect, useState } from "react";
+import { serviceTypeOperations } from "../utils/graphqlClient";
+import ServiceTypeCreate from "./ServiceTypeCreate";
+import TableFilters from "../components/TableFilters";
+import { openReactWindow } from "../utils/openReactWindow";
+
+export default function ServiceTypes() {
+    const [allServiceTypes, setAllServiceTypes] = useState([]);
+    const [serviceTypes, setServiceTypes] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
+
+    useEffect(() => { loadServiceTypes(); }, []);
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-servicetypes') {
+                loadServiceTypes();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
+    }, []);
+
+    const loadServiceTypes = async () => {
+        try {
+            setLoading(true);
+            const data = await serviceTypeOperations.getAllServicetypes();
+            setAllServiceTypes(data);
+            setServiceTypes(data);
+        } catch (err) {
+            console.error("Error cargando tipos de servicio:", err);
+            setError(err.message);
+            setServiceTypes([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleCreate = () => {
+        openReactWindow(
+            (popup) => (
+                <ServiceTypeCreate
+                    onSave={() => {
+                        popup.opener.postMessage('reload-servicetypes', '*');
+                        popup.close();
+                    }}
+                    onClose={() => popup.close()}
+                />
+            ),
+            'Nuevo Tipo de Servicio'
+        );
+    };
+
+    const handleFilterChange = (filtered) => setServiceTypes(filtered);
+
+    const handleEdit = (st) => {
+        openReactWindow(
+            (popup) => (
+                <ServiceTypeCreate
+                    serviceType={st}
+                    onSave={() => {
+                        popup.opener.postMessage('reload-servicetypes', '*');
+                        popup.close();
+                    }}
+                    onClose={() => popup.close()}
+                />
+            ),
+            'Editar Tipo de Servicio'
+        );
+    };
+
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar tipo de servicio?')) return;
+        try {
+            await serviceTypeOperations.deleteServicetype(id);
+            loadServiceTypes();
+        } catch (err) {
+            alert('Error al borrar tipo de servicio: ' + err.message);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold text-gray-800">Tipos de Servicio</h1>
+                <div className="flex space-x-2">
+                    <button
+                        onClick={() => setShowFilters(!showFilters)}
+                        className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700"
+                    >
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button onClick={loadServiceTypes} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                        Recargar
+                    </button>
+                    <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                        Nuevo Tipo
+                    </button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters modelName="servicetypes" data={allServiceTypes} onFilterChange={handleFilterChange} />
+                </div>
+            )}
+            {error && <div className="text-red-600 mb-4">{error}</div>}
+            {loading ? (
+                <div>Cargando...</div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {serviceTypes.map(st => (
+                        <div key={st.ServiceTypeID} className="bg-white rounded shadow p-4">
+                            <h3 className="text-lg font-semibold mb-2">{st.Type}</h3>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(st)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(st.ServiceTypeID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -612,6 +612,32 @@ export const MUTATIONS = {
         }
     `,
 
+    // TIPOS DE SERVICIO
+    CREATE_SERVICETYPE: `
+        mutation CreateServicetype($input: ServiceTypeCreate!) {
+            createServicetype(data: $input) {
+                ServiceTypeID
+                Type
+            }
+        }
+    `,
+    UPDATE_SERVICETYPE: `
+        mutation UpdateServicetype($serviceTypeID: Int!, $input: ServiceTypeUpdate!) {
+            updateServicetype(serviceTypeID: $serviceTypeID, data: $input) {
+                ServiceTypeID
+                Type
+            }
+        }
+    `,
+    DELETE_SERVICETYPE: `
+        mutation DeleteServicetype($serviceTypeID: Int!) {
+            deleteServicetype(serviceTypeID: $serviceTypeID) {
+                success
+                message
+            }
+        }
+    `,
+
     // ======= ORDENES - NUEVAS MUTACIONES CORREGIDAS =======
     CREATE_ORDER: `
         mutation CreateOrder($input: OrdersCreate!) {

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1179,6 +1179,18 @@ export const serviceTypeOperations = {
     async getServicetypeById(id) {
         const data = await graphqlClient.query(QUERIES.GET_SERVICETYPE_BY_ID, { id });
         return data.servicetypesById;
+    },
+    async createServicetype(input) {
+        const data = await graphqlClient.mutation(MUTATIONS.CREATE_SERVICETYPE, { input });
+        return data.createServicetype;
+    },
+    async updateServicetype(id, input) {
+        const data = await graphqlClient.mutation(MUTATIONS.UPDATE_SERVICETYPE, { serviceTypeID: id, input });
+        return data.updateServicetype;
+    },
+    async deleteServicetype(id) {
+        const data = await graphqlClient.mutation(MUTATIONS.DELETE_SERVICETYPE, { serviceTypeID: id });
+        return data.deleteServicetype;
     }
 };
 


### PR DESCRIPTION
## Summary
- enable filters for ServiceType
- expose ServiceType CRUD operations via GraphQL client
- add ServiceTypes pages with create form
- register ServiceTypes route and menu entry

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b4b6c2e748323a2cacda0f13a90a6