### PR TITLE
Add vendor CRUD module

### DIFF
--- a/app/graphql/mutations/vendors.py
+++ b/app/graphql/mutations/vendors.py
@@ -1,0 +1,63 @@
+# app/graphql/mutations/vendors.py
+import strawberry
+from typing import Optional
+from app.graphql.schemas.vendors import VendorsCreate, VendorsUpdate, VendorsInDB
+from app.graphql.crud.vendors import (
+    create_vendors,
+    update_vendors,
+    delete_vendors,
+)
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+@strawberry.type
+class VendorsMutations:
+    @strawberry.mutation
+    def create_vendor(self, info: Info, data: VendorsCreate) -> VendorsInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            new_vendor = create_vendors(db, data)
+            return obj_to_schema(VendorsInDB, new_vendor)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_vendor(
+        self, info: Info, vendorID: int, data: VendorsUpdate
+    ) -> Optional[VendorsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated_vendor = update_vendors(db, vendorID, data)
+            if not updated_vendor:
+                return None
+            return obj_to_schema(VendorsInDB, updated_vendor)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_vendor(self, info: Info, vendorID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted_vendor = delete_vendors(db, vendorID)
+            return deleted_vendor is not None
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def toggle_vendor_status(
+        self, info: Info, vendorID: int, isActive: bool
+    ) -> Optional[VendorsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            update_data = VendorsUpdate(IsActive=isActive)
+            updated_vendor = update_vendors(db, vendorID, update_data)
+            if not updated_vendor:
+                return None
+            return obj_to_schema(VendorsInDB, updated_vendor)
+        finally:
+            db_gen.close()

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -74,6 +74,7 @@ from app.graphql.mutations.documents import DocumentsMutations
 from app.graphql.mutations.useractions import UserActionsMutations
 from app.graphql.mutations.roles import RolesMutations
 from app.graphql.mutations.users import UsersMutations
+from app.graphql.mutations.vendors import VendorsMutations
 from app.graphql.mutations.useraccess import UserAccessMutation
 
 # IMPORTANTE: Importar las clases de autenticación correctamente
@@ -410,6 +411,7 @@ class Mutation(
     CreditCardGroupsMutations,
     CreditCardsMutations,
     DiscountsMutations,
+    VendorsMutations,
     BranchesMutations,
     CompanydataMutations,
     WarehousesMutations,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import SaleConditions from "./pages/SaleConditions";
 import CreditCardGroups from "./pages/CreditCardGroups";
 import CreditCards from "./pages/CreditCards";
 import Discounts from "./pages/Discounts";
+import Vendors from "./pages/Vendors";
 import ServiceTypes from "./pages/ServiceTypes";
 import Documents from "./pages/Documents";
 import Orders from "./pages/Orders";
@@ -204,6 +205,7 @@ export default function App() {
                     <Route path="creditcardgroups" element={<CreditCardGroups />} />
                     <Route path="creditcards" element={<CreditCards />} />
                     <Route path="discounts" element={<Discounts />} />
+                    <Route path="vendors" element={<Vendors />} />
                     <Route path="servicetypes" element={<ServiceTypes />} />
                     <Route path="itemcategories" element={<ItemCategories />} />
                     <Route path="itemsubcategories" element={<ItemSubcategories />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -79,6 +79,7 @@ export default function Sidebar() {
                         { label: "Grupos Tarjetas", to: "/creditcardgroups" },
                         { label: "Tarjetas", to: "/creditcards" },
                         { label: "Descuentos", to: "/discounts" },
+                        { label: "Vendedores", to: "/vendors" },
                         { label: "Tipos de servicio", to: "/servicetypes" },
                         { label: "Condiciones", to: "/saleconditions" },
                         { label: "Documentos", to: "/documents" },

--- a/frontend/src/pages/VendorCreate.jsx
+++ b/frontend/src/pages/VendorCreate.jsx
@@ -1,0 +1,104 @@
+// frontend/src/pages/VendorCreate.jsx
+import { useState, useEffect } from "react";
+import { vendorOperations } from "../utils/graphqlClient";
+
+export default function VendorCreate({ onClose, onSave, vendor: initialVendor = null }) {
+    const [vendorName, setVendorName] = useState("");
+    const [commission, setCommission] = useState("");
+    const [isActive, setIsActive] = useState(true);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [isEdit, setIsEdit] = useState(false);
+
+    useEffect(() => {
+        if (initialVendor) {
+            setIsEdit(true);
+            setVendorName(initialVendor.VendorName || "");
+            setCommission(initialVendor.Commission ?? "");
+            setIsActive(initialVendor.IsActive !== false);
+        }
+    }, [initialVendor]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+        try {
+            const payload = {
+                VendorName: vendorName,
+                Commission: commission === "" ? null : parseFloat(commission),
+                IsActive: isActive,
+            };
+            let result;
+            if (isEdit) {
+                result = await vendorOperations.updateVendor(initialVendor.VendorID, payload);
+            } else {
+                result = await vendorOperations.createVendor(payload);
+            }
+            onSave && onSave(result);
+            onClose && onClose();
+        } catch (err) {
+            console.error("Error guardando vendedor:", err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="p-6">
+            <h2 className="text-xl font-bold mb-4">{isEdit ? 'Editar Vendedor' : 'Nuevo Vendedor'}</h2>
+            {error && <div className="text-red-600 mb-2">{error}</div>}
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium mb-1">Nombre</label>
+                    <input
+                        type="text"
+                        value={vendorName}
+                        onChange={(e) => setVendorName(e.target.value)}
+                        className="w-full border border-gray-300 p-2 rounded"
+                        required
+                    />
+                </div>
+                <div>
+                    <label className="block text-sm font-medium mb-1">Comisión</label>
+                    <input
+                        type="number"
+                        step="0.01"
+                        value={commission}
+                        onChange={(e) => setCommission(e.target.value)}
+                        className="w-full border border-gray-300 p-2 rounded"
+                    />
+                </div>
+                <div>
+                    <label className="inline-flex items-center mt-2">
+                        <input
+                            type="checkbox"
+                            className="mr-2"
+                            checked={isActive}
+                            onChange={(e) => setIsActive(e.target.checked)}
+                        />
+                        <span>Vendedor activo</span>
+                    </label>
+                </div>
+                <div className="flex justify-end space-x-4 pt-4 border-t">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        disabled={loading}
+                        className="px-4 py-2 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+                    >
+                        Cancelar
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={loading || !vendorName.trim()}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                        {loading ? 'Guardando...' : 'Guardar'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/frontend/src/pages/Vendors.jsx
+++ b/frontend/src/pages/Vendors.jsx
@@ -1,0 +1,136 @@
+// frontend/src/pages/Vendors.jsx
+import { useEffect, useState } from "react";
+import { vendorOperations } from "../utils/graphqlClient";
+import VendorCreate from "./VendorCreate";
+import TableFilters from "../components/TableFilters";
+import { openReactWindow } from "../utils/openReactWindow";
+
+export default function Vendors() {
+    const [allVendors, setAllVendors] = useState([]);
+    const [vendors, setVendors] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const [showFilters, setShowFilters] = useState(false);
+
+    useEffect(() => { loadVendors(); }, []);
+
+    useEffect(() => {
+        const handler = (e) => {
+            if (e.data === 'reload-vendors') {
+                loadVendors();
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
+    }, []);
+
+    const loadVendors = async () => {
+        try {
+            setLoading(true);
+            const data = await vendorOperations.getAllVendors();
+            setAllVendors(data);
+            setVendors(data);
+        } catch (err) {
+            console.error("Error cargando vendedores:", err);
+            setError(err.message);
+            setVendors([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleCreate = () => {
+        openReactWindow(
+            (popup) => (
+                <VendorCreate
+                    onSave={() => {
+                        popup.opener.postMessage('reload-vendors', '*');
+                        popup.close();
+                    }}
+                    onClose={() => popup.close()}
+                />
+            ),
+            'Nuevo Vendedor'
+        );
+    };
+
+    const handleEdit = (vendor) => {
+        openReactWindow(
+            (popup) => (
+                <VendorCreate
+                    vendor={vendor}
+                    onSave={() => {
+                        popup.opener.postMessage('reload-vendors', '*');
+                        popup.close();
+                    }}
+                    onClose={() => popup.close()}
+                />
+            ),
+            'Editar Vendedor'
+        );
+    };
+
+    const handleDelete = async (id) => {
+        if (!confirm('¿Borrar vendedor?')) return;
+        try {
+            await vendorOperations.deleteVendor(id);
+            loadVendors();
+        } catch (err) {
+            alert('Error al borrar vendedor: ' + err.message);
+        }
+    };
+
+    const handleFilterChange = (filtered) => {
+        setVendors(filtered);
+    };
+
+    return (
+        <div className="p-6">
+            <div className="flex items-center justify-between mb-6">
+                <h1 className="text-3xl font-bold text-gray-800">Vendedores</h1>
+                <div className="flex space-x-2">
+                    <button
+                        onClick={() => setShowFilters(!showFilters)}
+                        className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700"
+                    >
+                        {showFilters ? 'Ocultar Filtros' : 'Mostrar Filtros'}
+                    </button>
+                    <button
+                        onClick={loadVendors}
+                        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                    >
+                        Recargar
+                    </button>
+                    <button onClick={handleCreate} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                        Nuevo Vendedor
+                    </button>
+                </div>
+            </div>
+            {showFilters && (
+                <div className="mb-6">
+                    <TableFilters modelName="vendors" data={allVendors} onFilterChange={handleFilterChange} />
+                </div>
+            )}
+            {error && <div className="text-red-600 mb-4">{error}</div>}
+            {loading ? (
+                <div>Cargando...</div>
+            ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {vendors.map(v => (
+                        <div key={v.VendorID} className="bg-white rounded shadow p-4">
+                            <h3 className="text-lg font-semibold mb-2">{v.VendorName}</h3>
+                            {v.Commission !== null && (
+                                <p className="text-sm mb-1">Comisión: {v.Commission}</p>
+                            )}
+                            <p className="text-sm mb-2">Activo: {v.IsActive ? 'Sí' : 'No'}</p>
+                            <div className="flex space-x-2">
+                                <button onClick={() => handleEdit(v)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
+                                <button onClick={() => handleDelete(v.VendorID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -128,6 +128,44 @@ export const MUTATIONS = {
         }
     `,
 
+    // VENDEDORES
+    CREATE_VENDOR: `
+        mutation CreateVendor($input: VendorsCreate!) {
+            createVendor(data: $input) {
+                VendorID
+                VendorName
+                Commission
+                IsActive
+            }
+        }
+    `,
+    UPDATE_VENDOR: `
+        mutation UpdateVendor($vendorID: Int!, $input: VendorsUpdate!) {
+            updateVendor(vendorID: $vendorID, data: $input) {
+                VendorID
+                VendorName
+                Commission
+                IsActive
+            }
+        }
+    `,
+    DELETE_VENDOR: `
+        mutation DeleteVendor($vendorID: Int!) {
+            deleteVendor(vendorID: $vendorID) {
+                success
+                message
+            }
+        }
+    `,
+    TOGGLE_VENDOR_STATUS: `
+        mutation ToggleVendorStatus($vendorID: Int!, $isActive: Boolean!) {
+            toggleVendorStatus(vendorID: $vendorID, isActive: $isActive) {
+                VendorID
+                IsActive
+            }
+        }
+    `,
+
     // MARCAS
     CREATE_BRAND: `
         mutation CreateBrand($input: BrandsCreate!) {

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -220,6 +220,52 @@ export const vendorOperations = {
             console.error("Error obteniendo vendedores:", error);
             throw error;
         }
+    },
+    async createVendor(vendorData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.CREATE_VENDOR, {
+                input: vendorData
+            });
+            return data.createVendor;
+        } catch (error) {
+            console.error("Error creando vendedor:", error);
+            throw error;
+        }
+    },
+    async updateVendor(id, vendorData) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_VENDOR, {
+                vendorID: id,
+                input: vendorData
+            });
+            return data.updateVendor;
+        } catch (error) {
+            console.error("Error actualizando vendedor:", error);
+            throw error;
+        }
+    },
+    async deleteVendor(id) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.DELETE_VENDOR, {
+                vendorID: id
+            });
+            return data.deleteVendor;
+        } catch (error) {
+            console.error("Error eliminando vendedor:", error);
+            throw error;
+        }
+    },
+    async toggleVendorStatus(id, isActive) {
+        try {
+            const data = await graphqlClient.mutation(MUTATIONS.TOGGLE_VENDOR_STATUS, {
+                vendorID: id,
+                isActive
+            });
+            return data.toggleVendorStatus;
+        } catch (error) {
+            console.error("Error cambiando estado del vendedor:", error);
+            throw error;
+        }
     }
 };
 

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -163,6 +163,17 @@ export const QUERIES = {
             }
         }
     `,
+    // Alias para compatibilidad
+    GET_ALL_VENDORS: `
+        query GetAllVendors {
+            allVendors {
+                VendorID
+                VendorName
+                Commission
+                IsActive
+            }
+        }
+    `,
 
     GET_ALL_USERS: `
         query GetAllUsers {


### PR DESCRIPTION
## Summary
- include vendors mutations in backend schema and CRUD operations
- expose vendor API endpoints in frontend
- add vendor list page and creation form
- update sidebar navigation and routing

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687b4fd4b46c8323a34a7346a8845236