### PR TITLE
Fix AFIP voucher schema for large CUIT values

### DIFF
--- a/app/graphql/resolvers/afip.py
+++ b/app/graphql/resolvers/afip.py
@@ -17,5 +17,11 @@ class AfipQuery:
     @strawberry.field
     def informacion_comprobante(self, info: Info, data: VoucherRequest) -> VoucherInfo:
         """Consulta la información de un comprobante en AFIP."""
-        res = constatar_comprobante(data.__dict__)
+        cmp_req = data.__dict__.copy()
+        if isinstance(cmp_req.get("CuitEmisor"), str):
+            try:
+                cmp_req["CuitEmisor"] = int(cmp_req["CuitEmisor"])
+            except ValueError:
+                pass
+        res = constatar_comprobante(cmp_req)
         return VoucherInfo(raw=json.dumps(res))

--- a/app/graphql/schemas/afip.py
+++ b/app/graphql/schemas/afip.py
@@ -6,7 +6,7 @@ from typing import Optional
 @strawberry.input
 class VoucherRequest:
     CbteModo: str
-    CuitEmisor: int
+    CuitEmisor: str
     PtoVta: int
     CbteTipo: int
     CbteNro: int


### PR DESCRIPTION
## Summary
- allow `CuitEmisor` to be sent as string in GraphQL schema
- cast CUIT back to int in AFIP resolver before calling `wscdc`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b68a8b1c8832395f7be9ef76bd348