### PR TITLE
Add price list item assignment feature

### DIFF
--- a/app/graphql/crud/pricelistitems.py
+++ b/app/graphql/crud/pricelistitems.py
@@ -1,4 +1,4 @@
-# graphql/crud/pricelistitems.py
+# app/graphql/crud/pricelistitems.py
 from sqlalchemy.orm import Session
 from app.models.pricelistitems import PriceListItems
 from app.graphql.schemas.pricelistitems import (
@@ -11,15 +11,29 @@ def get_pricelistitems(db: Session):
     return db.query(PriceListItems).all()
 
 
-def get_pricelistitems_by_id(db: Session, pricelistitemid: int):
+def get_pricelistitem(db: Session, pricelist_id: int, item_id: int):
     return (
         db.query(PriceListItems)
-        .filter(PriceListItems.priceListItemID == pricelistitemid)
+        .filter(
+            PriceListItems.PriceListID == pricelist_id,
+            PriceListItems.ItemID == item_id,
+        )
         .first()
     )
 
 
-def create_pricelistitems(db: Session, data: PriceListItemsCreate):
+def get_pricelistitems_filtered(
+    db: Session, pricelist_id: int | None = None, item_id: int | None = None
+):
+    query = db.query(PriceListItems)
+    if pricelist_id is not None:
+        query = query.filter(PriceListItems.PriceListID == pricelist_id)
+    if item_id is not None:
+        query = query.filter(PriceListItems.ItemID == item_id)
+    return query.all()
+
+
+def create_pricelistitem(db: Session, data: PriceListItemsCreate):
     obj = PriceListItems(**vars(data))
     db.add(obj)
     db.commit()
@@ -27,10 +41,10 @@ def create_pricelistitems(db: Session, data: PriceListItemsCreate):
     return obj
 
 
-def update_pricelistitems(
-    db: Session, pricelistitemid: int, data: PriceListItemsUpdate
+def update_pricelistitem(
+    db: Session, pricelist_id: int, item_id: int, data: PriceListItemsUpdate
 ):
-    obj = get_pricelistitems_by_id(db, pricelistitemid)
+    obj = get_pricelistitem(db, pricelist_id, item_id)
     if obj:
         for k, v in vars(data).items():
             if v is not None:
@@ -40,9 +54,10 @@ def update_pricelistitems(
     return obj
 
 
-def delete_pricelistitems(db: Session, pricelistitemid: int):
-    obj = get_pricelistitems_by_id(db, pricelistitemid)
+def delete_pricelistitem(db: Session, pricelist_id: int, item_id: int):
+    obj = get_pricelistitem(db, pricelist_id, item_id)
     if obj:
         db.delete(obj)
         db.commit()
     return obj
+

--- a/app/graphql/mutations/pricelistitems.py
+++ b/app/graphql/mutations/pricelistitems.py
@@ -1,0 +1,47 @@
+# app/graphql/mutations/pricelistitems.py
+import strawberry
+from typing import Optional
+from app.graphql.schemas.pricelistitems import PriceListItemsCreate, PriceListItemsUpdate, PriceListItemsInDB
+from app.graphql.crud.pricelistitems import (
+    create_pricelistitem,
+    update_pricelistitem,
+    delete_pricelistitem,
+)
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+@strawberry.type
+class PricelistitemsMutations:
+    @strawberry.mutation
+    def create_pricelistitem(self, info: Info, data: PriceListItemsCreate) -> PriceListItemsInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            obj = create_pricelistitem(db, data)
+            return obj_to_schema(PriceListItemsInDB, obj)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_pricelistitem(
+        self, info: Info, pricelistID: int, itemID: int, data: PriceListItemsUpdate
+    ) -> Optional[PriceListItemsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated = update_pricelistitem(db, pricelistID, itemID, data)
+            return obj_to_schema(PriceListItemsInDB, updated) if updated else None
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_pricelistitem(self, info: Info, pricelistID: int, itemID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_pricelistitem(db, pricelistID, itemID)
+            return deleted is not None
+        finally:
+            db_gen.close()
+

--- a/app/graphql/resolvers/pricelistitems.py
+++ b/app/graphql/resolvers/pricelistitems.py
@@ -2,7 +2,11 @@
 import strawberry
 from typing import List, Optional
 from app.graphql.schemas.pricelistitems import PriceListItemsInDB
-from app.graphql.crud.pricelistitems import get_pricelistitems, get_pricelistitems_by_id
+from app.graphql.crud.pricelistitems import (
+    get_pricelistitems,
+    get_pricelistitem,
+    get_pricelistitems_filtered,
+)
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
 from strawberry.types import Info
@@ -21,14 +25,29 @@ class PricelistitemsQuery:
             db_gen.close()
 
     @strawberry.field
-    def pricelistitems_by_id(self, info: Info, id: int) -> Optional[PriceListItemsInDB]:
+    def pricelistitem_by_ids(
+        self, info: Info, pricelistID: int, itemID: int
+    ) -> Optional[PriceListItemsInDB]:
         db_gen = get_db()
         db = next(db_gen)
         try:
-            item = get_pricelistitems_by_id(db, id)
+            item = get_pricelistitem(db, pricelistID, itemID)
             return obj_to_schema(PriceListItemsInDB, item) if item else None
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def pricelistitems_filtered(
+        self, info: Info, pricelistID: Optional[int] = None, itemID: Optional[int] = None
+    ) -> List[PriceListItemsInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            items = get_pricelistitems_filtered(db, pricelistID, itemID)
+            return list_to_schema(PriceListItemsInDB, items)
         finally:
             db_gen.close()
 
 
 pricelistitemsQuery = PricelistitemsQuery()
+

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -67,6 +67,7 @@ from app.graphql.mutations.branches import BranchesMutations
 from app.graphql.mutations.companydata import CompanydataMutations
 from app.graphql.mutations.warehouses import WarehousesMutations
 from app.graphql.mutations.pricelists import PricelistsMutations
+from app.graphql.mutations.pricelistitems import PricelistitemsMutations
 from app.graphql.mutations.temporderdetails import TempOrderDetailsMutations
 from app.graphql.mutations.orders import OrdersMutations
 from app.graphql.mutations.servicetype import ServiceTypeMutations
@@ -418,6 +419,7 @@ class Mutation(
     CompanydataMutations,
     WarehousesMutations,
     PricelistsMutations,
+    PricelistitemsMutations,
     TempOrderDetailsMutations,
     OrdersMutations,
     ServiceTypeMutations,

--- a/app/graphql/schemas/pricelistitems.py
+++ b/app/graphql/schemas/pricelistitems.py
@@ -8,19 +8,17 @@ class PriceListItemsCreate:
     PriceListID: int
     ItemID: int
     Price: float
-    EffectiveDate: datetime
+    EffectiveDate: Optional[datetime] = None
 
 @strawberry.input
 class PriceListItemsUpdate:
-    PriceListID: Optional[int] = None
-    ItemID: Optional[int] = None
     Price: Optional[float] = None
     EffectiveDate: Optional[datetime] = None
 
 @strawberry.type
 class PriceListItemsInDB:
-    PriceListItemID: int
     PriceListID: int
     ItemID: int
     Price: float
     EffectiveDate: datetime
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ import ItemCategories from "./pages/ItemCategories";
 import ItemSubcategories from "./pages/ItemSubcategories";
 import Items from "./pages/Items";
 import PriceLists from "./pages/PriceLists";
+import PriceListItemsPage from "./pages/PriceListItems";
 import Warehouses from "./pages/Warehouses";
 import SaleConditions from "./pages/SaleConditions";
 import CreditCardGroups from "./pages/CreditCardGroups";
@@ -213,6 +214,7 @@ export default function App() {
                     <Route path="itemsubcategories" element={<ItemSubcategories />} />
                     <Route path="items" element={<Items />} />
                     <Route path="pricelists" element={<PriceLists />} />
+                    <Route path="pricelistitems" element={<PriceListItemsPage />} />
                     <Route path="warehouses" element={<Warehouses />} />
                     <Route path="branches" element={<Branches />} />
                     <Route path="companydata" element={<CompanyData />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 
 import OrderCreate from "../pages/OrderCreate";
+import PriceListItemsPage from "../pages/PriceListItems";
 import { openReactWindow } from "../utils/openReactWindow";
 
 export default function Sidebar() {
@@ -71,6 +72,7 @@ export default function Sidebar() {
                         { label: "Ítems", to: "/items" },
                         { label: "Depósitos", to: "/warehouses" },
                         { label: "Listas de precios", to: "/pricelists" },
+                        { label: "Asignar precios a ítems", action: () => openPopup(PriceListItemsPage, "Asignar precios", 1000, 700) },
                     ],
                 },
                 {

--- a/frontend/src/pages/PriceListItems.jsx
+++ b/frontend/src/pages/PriceListItems.jsx
@@ -1,0 +1,110 @@
+// frontend/src/pages/PriceListItems.jsx
+import { useEffect, useState } from "react";
+import { pricelistOperations, pricelistItemOperations } from "../utils/graphqlClient";
+import ItemSearchModal from "../components/ItemSearchModal";
+
+export default function PriceListItems({ onClose }) {
+    const [priceLists, setPriceLists] = useState([]);
+    const [selectedList, setSelectedList] = useState("");
+    const [items, setItems] = useState([]);
+    const [showModal, setShowModal] = useState(false);
+    const [existing, setExisting] = useState([]);
+
+    useEffect(() => {
+        pricelistOperations.getAllPricelists().then(setPriceLists);
+        loadExisting();
+    }, []);
+
+    const loadExisting = async (listId, itemId) => {
+        const data = await pricelistItemOperations.getFiltered(listId || null, itemId || null);
+        setExisting(data);
+    };
+
+    const addItem = (it) => {
+        if (items.some(i => i.ItemID === it.itemID)) return;
+        const price = 0;
+        setItems(prev => [...prev, { ItemID: it.itemID, Code: it.code, Description: it.description, Price: price }]);
+        setShowModal(false);
+    };
+
+    const updatePrice = (id, value) => {
+        setItems(prev => prev.map(it => it.ItemID === id ? { ...it, Price: value } : it));
+    };
+
+    const handleSave = async () => {
+        if (!selectedList) return;
+        for (const it of items) {
+            await pricelistItemOperations.createPricelistItem({
+                PriceListID: Number(selectedList),
+                ItemID: it.ItemID,
+                Price: parseFloat(it.Price)
+            });
+        }
+        setItems([]);
+        loadExisting(selectedList);
+    };
+
+    return (
+        <div className="p-6 space-y-4">
+            <h2 className="text-xl font-bold">Asignar precios a ítems</h2>
+            <div className="flex gap-2 items-center">
+                <select value={selectedList} onChange={e => {setSelectedList(e.target.value); loadExisting(e.target.value);}} className="border p-2 rounded">
+                    <option value="">Seleccione lista</option>
+                    {priceLists.map(pl => (
+                        <option key={pl.PriceListID} value={pl.PriceListID}>{pl.Name}</option>
+                    ))}
+                </select>
+                <button onClick={() => setShowModal(true)} className="px-4 py-2 bg-blue-600 text-white rounded">Agregar Ítems</button>
+                <button onClick={handleSave} className="px-4 py-2 bg-green-600 text-white rounded">Guardar</button>
+                <button onClick={onClose} className="px-4 py-2 border rounded">Cerrar</button>
+            </div>
+            {items.length > 0 && (
+                <table className="min-w-full text-sm">
+                    <thead>
+                        <tr>
+                            <th className="px-2 text-left">Código</th>
+                            <th className="px-2 text-left">Descripción</th>
+                            <th className="px-2">Precio</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {items.map(it => (
+                            <tr key={it.ItemID}>
+                                <td className="border px-2">{it.Code}</td>
+                                <td className="border px-2">{it.Description}</td>
+                                <td className="border px-2">
+                                    <input type="number" step="0.01" value={it.Price} onChange={e => updatePrice(it.ItemID, e.target.value)} className="w-24 border p-1 rounded" />
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+            <h3 className="font-semibold">Existentes</h3>
+            <table className="min-w-full text-sm">
+                <thead>
+                    <tr>
+                        <th className="px-2 text-left">Lista</th>
+                        <th className="px-2 text-left">Item</th>
+                        <th className="px-2">Precio</th>
+                        <th className="px-2">Fecha</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {existing.map(pl => (
+                        <tr key={`${pl.PriceListID}-${pl.ItemID}`}>\
+                            <td className="border px-2">{pl.PriceListID}</td>
+                            <td className="border px-2">{pl.ItemID}</td>
+                            <td className="border px-2">{pl.Price}</td>
+                            <td className="border px-2">{pl.EffectiveDate?.slice(0,10)}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+            {showModal && (
+                <ItemSearchModal isOpen={true} onClose={() => setShowModal(false)} onItemSelect={addItem} />
+            )}
+        </div>
+    );
+}
+

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -565,6 +565,31 @@ export const MUTATIONS = {
             }
         }
     `,
+    CREATE_PRICELIST_ITEM: `
+        mutation CreatePricelistItem($input: PriceListItemsCreate!) {
+            createPricelistitem(data: $input) {
+                PriceListID
+                ItemID
+                Price
+                EffectiveDate
+            }
+        }
+    `,
+    UPDATE_PRICELIST_ITEM: `
+        mutation UpdatePricelistItem($pricelistID: Int!, $itemID: Int!, $input: PriceListItemsUpdate!) {
+            updatePricelistitem(pricelistID: $pricelistID, itemID: $itemID, data: $input) {
+                PriceListID
+                ItemID
+                Price
+                EffectiveDate
+            }
+        }
+    `,
+    DELETE_PRICELIST_ITEM: `
+        mutation DeletePricelistItem($pricelistID: Int!, $itemID: Int!) {
+            deletePricelistitem(pricelistID: $pricelistID, itemID: $itemID)
+        }
+    `,
     CREATE_WAREHOUSE: `
         mutation CreateWarehouse($input: WarehousesCreate!) {
             createWarehouse(data: $input) {

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1195,6 +1195,29 @@ export const pricelistOperations = {
     }
 };
 
+export const pricelistItemOperations = {
+    async getAllPricelistItems() {
+        const data = await graphqlClient.query(QUERIES.GET_ALL_PRICELIST_ITEMS);
+        return data.allPricelistitems || [];
+    },
+    async getFiltered(priceListID, itemID) {
+        const data = await graphqlClient.query(QUERIES.GET_PRICELIST_ITEMS_FILTERED, { priceListID, itemID });
+        return data.pricelistitemsFiltered || [];
+    },
+    async createPricelistItem(input) {
+        const data = await graphqlClient.mutation(MUTATIONS.CREATE_PRICELIST_ITEM, { input });
+        return data.createPricelistitem;
+    },
+    async updatePricelistItem(priceListID, itemID, input) {
+        const data = await graphqlClient.mutation(MUTATIONS.UPDATE_PRICELIST_ITEM, { pricelistID: priceListID, itemID, input });
+        return data.updatePricelistitem;
+    },
+    async deletePricelistItem(priceListID, itemID) {
+        const data = await graphqlClient.mutation(MUTATIONS.DELETE_PRICELIST_ITEM, { pricelistID: priceListID, itemID });
+        return data.deletePricelistitem;
+    }
+};
+
 export const warehouseOperations = {
     async getAllWarehouses() {
         const data = await graphqlClient.query(QUERIES.GET_ALL_WAREHOUSES);

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -106,6 +106,26 @@ export const QUERIES = {
             }
         }
     `,
+    GET_ALL_PRICELIST_ITEMS: `
+        query GetAllPricelistItems {
+            allPricelistitems {
+                PriceListID
+                ItemID
+                Price
+                EffectiveDate
+            }
+        }
+    `,
+    GET_PRICELIST_ITEMS_FILTERED: `
+        query GetPricelistItemsFiltered($priceListID: Int, $itemID: Int) {
+            pricelistitemsFiltered(pricelistID: $priceListID, itemID: $itemID) {
+                PriceListID
+                ItemID
+                Price
+                EffectiveDate
+            }
+        }
+    `,
     GET_ALL_WAREHOUSES: `
         query GetWarehouses {
             allWarehouses {


### PR DESCRIPTION
## Summary
- support managing price list items in backend with CRUD functions and GraphQL
- expose queries and mutations for price list items
- add frontend operations and GraphQL queries/mutations
- create PriceListItems page for assigning prices to items
- open new page from sidebar submenu

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ba11cf7d0832392667ba7e6067c01