### PR TITLE
Fix missing stock history models and GraphQL bindings

### DIFF
--- a/app/graphql/crud/stockhistory.py
+++ b/app/graphql/crud/stockhistory.py
@@ -1,0 +1,41 @@
+# app/graphql/crud/stockhistory.py
+from sqlalchemy.orm import Session
+from app.models.stockhistory import StockHistory
+from app.graphql.schemas.stockhistory import StockHistoryCreate, StockHistoryUpdate
+
+
+def get_stockhistory(db: Session):
+    return db.query(StockHistory).all()
+
+
+def get_stockhistory_by_id(db: Session, history_id: int):
+    return (
+        db.query(StockHistory).filter(StockHistory.StockHistoryID == history_id).first()
+    )
+
+
+def create_stockhistory(db: Session, data: StockHistoryCreate):
+    obj = StockHistory(**vars(data))
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+def update_stockhistory(db: Session, history_id: int, data: StockHistoryUpdate):
+    obj = get_stockhistory_by_id(db, history_id)
+    if obj:
+        for k, v in vars(data).items():
+            if v is not None:
+                setattr(obj, k, v)
+        db.commit()
+        db.refresh(obj)
+    return obj
+
+
+def delete_stockhistory(db: Session, history_id: int):
+    obj = get_stockhistory_by_id(db, history_id)
+    if obj:
+        db.delete(obj)
+        db.commit()
+    return obj

--- a/app/graphql/crud/tempstockentries.py
+++ b/app/graphql/crud/tempstockentries.py
@@ -1,0 +1,46 @@
+# app/graphql/crud/tempstockentries.py
+from sqlalchemy.orm import Session
+from app.models.tempstockentries import TempStockEntries
+from app.graphql.schemas.tempstockentries import (
+    TempStockEntriesCreate,
+    TempStockEntriesUpdate,
+)
+
+
+def get_tempstockentries(db: Session):
+    return db.query(TempStockEntries).all()
+
+
+def get_tempstockentries_by_id(db: Session, entry_id: int):
+    return (
+        db.query(TempStockEntries)
+        .filter(TempStockEntries.TempStockEntryID == entry_id)
+        .first()
+    )
+
+
+def create_tempstockentries(db: Session, data: TempStockEntriesCreate):
+    obj = TempStockEntries(**vars(data))
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+def update_tempstockentries(db: Session, entry_id: int, data: TempStockEntriesUpdate):
+    obj = get_tempstockentries_by_id(db, entry_id)
+    if obj:
+        for k, v in vars(data).items():
+            if v is not None:
+                setattr(obj, k, v)
+        db.commit()
+        db.refresh(obj)
+    return obj
+
+
+def delete_tempstockentries(db: Session, entry_id: int):
+    obj = get_tempstockentries_by_id(db, entry_id)
+    if obj:
+        db.delete(obj)
+        db.commit()
+    return obj

--- a/app/graphql/mutations/stockhistory.py
+++ b/app/graphql/mutations/stockhistory.py
@@ -1,0 +1,53 @@
+# app/graphql/mutations/stockhistory.py
+import strawberry
+from typing import Optional
+from app.graphql.schemas.stockhistory import (
+    StockHistoryCreate,
+    StockHistoryUpdate,
+    StockHistoryInDB,
+)
+from app.graphql.crud.stockhistory import (
+    create_stockhistory,
+    update_stockhistory,
+    delete_stockhistory,
+)
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+
+@strawberry.type
+class StockHistoryMutations:
+    @strawberry.mutation
+    def create_stockhistory(
+        self, info: Info, data: StockHistoryCreate
+    ) -> StockHistoryInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            obj = create_stockhistory(db, data)
+            return obj_to_schema(StockHistoryInDB, obj)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_stockhistory(
+        self, info: Info, historyID: int, data: StockHistoryUpdate
+    ) -> Optional[StockHistoryInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated = update_stockhistory(db, historyID, data)
+            return obj_to_schema(StockHistoryInDB, updated) if updated else None
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_stockhistory(self, info: Info, historyID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_stockhistory(db, historyID)
+            return deleted is not None
+        finally:
+            db_gen.close()

--- a/app/graphql/mutations/tempstockentries.py
+++ b/app/graphql/mutations/tempstockentries.py
@@ -1,0 +1,53 @@
+# app/graphql/mutations/tempstockentries.py
+import strawberry
+from typing import Optional
+from app.graphql.schemas.tempstockentries import (
+    TempStockEntriesCreate,
+    TempStockEntriesUpdate,
+    TempStockEntriesInDB,
+)
+from app.graphql.crud.tempstockentries import (
+    create_tempstockentries,
+    update_tempstockentries,
+    delete_tempstockentries,
+)
+from app.utils import obj_to_schema
+from app.db import get_db
+from strawberry.types import Info
+
+
+@strawberry.type
+class TempStockEntriesMutations:
+    @strawberry.mutation
+    def create_tempstockentry(
+        self, info: Info, data: TempStockEntriesCreate
+    ) -> TempStockEntriesInDB:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            obj = create_tempstockentries(db, data)
+            return obj_to_schema(TempStockEntriesInDB, obj)
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def update_tempstockentry(
+        self, info: Info, entryID: int, data: TempStockEntriesUpdate
+    ) -> Optional[TempStockEntriesInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            updated = update_tempstockentries(db, entryID, data)
+            return obj_to_schema(TempStockEntriesInDB, updated) if updated else None
+        finally:
+            db_gen.close()
+
+    @strawberry.mutation
+    def delete_tempstockentry(self, info: Info, entryID: int) -> bool:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            deleted = delete_tempstockentries(db, entryID)
+            return deleted is not None
+        finally:
+            db_gen.close()

--- a/app/graphql/resolvers/stockhistory.py
+++ b/app/graphql/resolvers/stockhistory.py
@@ -1,0 +1,34 @@
+# app/graphql/resolvers/stockhistory.py
+import strawberry
+from typing import List, Optional
+from app.graphql.schemas.stockhistory import StockHistoryInDB
+from app.graphql.crud.stockhistory import get_stockhistory, get_stockhistory_by_id
+from app.db import get_db
+from app.utils import list_to_schema, obj_to_schema
+from strawberry.types import Info
+
+
+@strawberry.type
+class StockhistoryQuery:
+    @strawberry.field
+    def all_stockhistory(self, info: Info) -> List[StockHistoryInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            records = get_stockhistory(db)
+            return list_to_schema(StockHistoryInDB, records)
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def stockhistory_by_id(self, info: Info, id: int) -> Optional[StockHistoryInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            obj = get_stockhistory_by_id(db, id)
+            return obj_to_schema(StockHistoryInDB, obj) if obj else None
+        finally:
+            db_gen.close()
+
+
+stockhistoryQuery = StockhistoryQuery()

--- a/app/graphql/resolvers/tempstockentries.py
+++ b/app/graphql/resolvers/tempstockentries.py
@@ -1,0 +1,39 @@
+# app/graphql/resolvers/tempstockentries.py
+import strawberry
+from typing import List, Optional
+from app.graphql.schemas.tempstockentries import TempStockEntriesInDB
+from app.graphql.crud.tempstockentries import (
+    get_tempstockentries,
+    get_tempstockentries_by_id,
+)
+from app.db import get_db
+from app.utils import list_to_schema, obj_to_schema
+from strawberry.types import Info
+
+
+@strawberry.type
+class TempstockentriesQuery:
+    @strawberry.field
+    def all_tempstockentries(self, info: Info) -> List[TempStockEntriesInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            entries = get_tempstockentries(db)
+            return list_to_schema(TempStockEntriesInDB, entries)
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def tempstockentries_by_id(
+        self, info: Info, id: int
+    ) -> Optional[TempStockEntriesInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            entry = get_tempstockentries_by_id(db, id)
+            return obj_to_schema(TempStockEntriesInDB, entry) if entry else None
+        finally:
+            db_gen.close()
+
+
+tempstockentriesQuery = TempstockentriesQuery()

--- a/app/graphql/schemas/stockhistory.py
+++ b/app/graphql/schemas/stockhistory.py
@@ -1,0 +1,45 @@
+# app/graphql/schemas/stockhistory.py
+import strawberry
+from typing import Optional
+from datetime import datetime
+
+
+@strawberry.input
+class StockHistoryCreate:
+    ItemID: int
+    CompanyID: int
+    BranchID: int
+    WarehouseID: int
+    QuantityUpdate: int
+    QuantityBefore: int
+    QuantityAfter: int
+    Reason: Optional[str] = None
+    UserID: int
+
+
+@strawberry.input
+class StockHistoryUpdate:
+    ItemID: Optional[int] = None
+    CompanyID: Optional[int] = None
+    BranchID: Optional[int] = None
+    WarehouseID: Optional[int] = None
+    QuantityUpdate: Optional[int] = None
+    QuantityBefore: Optional[int] = None
+    QuantityAfter: Optional[int] = None
+    Reason: Optional[str] = None
+    UserID: Optional[int] = None
+
+
+@strawberry.type
+class StockHistoryInDB:
+    StockHistoryID: int
+    ItemID: int
+    CompanyID: int
+    BranchID: int
+    WarehouseID: int
+    QuantityUpdate: int
+    QuantityBefore: int
+    QuantityAfter: int
+    TransactionDate: datetime
+    Reason: Optional[str]
+    UserID: int

--- a/app/graphql/schemas/tempstockentries.py
+++ b/app/graphql/schemas/tempstockentries.py
@@ -1,0 +1,46 @@
+# app/graphql/schemas/tempstockentries.py
+import strawberry
+from typing import Optional
+from datetime import datetime
+from uuid import UUID
+
+
+@strawberry.input
+class TempStockEntriesCreate:
+    CompanyID: int
+    BranchID: int
+    SessionID: str
+    UserID: int
+    ItemID: int
+    WarehouseID: int
+    Quantity: int
+    Reason: Optional[str] = None
+
+
+@strawberry.input
+class TempStockEntriesUpdate:
+    CompanyID: Optional[int] = None
+    BranchID: Optional[int] = None
+    SessionID: Optional[str] = None
+    UserID: Optional[int] = None
+    ItemID: Optional[int] = None
+    WarehouseID: Optional[int] = None
+    Quantity: Optional[int] = None
+    Reason: Optional[str] = None
+    IsProcessed: Optional[bool] = None
+
+
+@strawberry.type
+class TempStockEntriesInDB:
+    TempStockEntryID: int
+    CompanyID: int
+    BranchID: int
+    UniqueID: UUID
+    SessionID: str
+    UserID: int
+    ItemID: int
+    WarehouseID: int
+    Quantity: int
+    EntryDate: datetime
+    Reason: Optional[str]
+    IsProcessed: bool

--- a/app/models/stockhistory.py
+++ b/app/models/stockhistory.py
@@ -1,0 +1,74 @@
+# ========== StockHistory ===========
+# app/models/stockhistory.py
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .items import Items
+    from .warehouses import Warehouses
+    from .branches import Branches
+    from .companydata import CompanyData
+    from .users import Users
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    DateTime,
+    Unicode,
+    Identity,
+    PrimaryKeyConstraint,
+    ForeignKeyConstraint,
+    text,
+)
+from sqlalchemy.orm import Mapped, relationship
+
+from app.db import Base
+
+
+class StockHistory(Base):
+    __tablename__ = "StockHistory"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["ItemID"], ["Items.ItemID"], name="FK__StockHist__ItemI__7A672E12"
+        ),
+        ForeignKeyConstraint(
+            ["WarehouseID"],
+            ["Warehouses.WarehouseID"],
+            name="FK__StockHist__Wareh__7B5B524B",
+        ),
+        ForeignKeyConstraint(
+            ["BranchID"], ["Branches.BranchID"], name="FK_StockHistory_Branches"
+        ),
+        ForeignKeyConstraint(
+            ["CompanyID"], ["CompanyData.CompanyID"], name="FK_StockHistory_CompanyData"
+        ),
+        ForeignKeyConstraint(
+            ["UserID"], ["Users.UserID"], name="FK_StockHistory_Users"
+        ),
+        PrimaryKeyConstraint("StockHistoryID", name="PK__StockHis__A6CE86DBEB46B995"),
+    )
+
+    StockHistoryID = Column(Integer, Identity(start=1, increment=1), primary_key=True)
+    ItemID = Column(Integer)
+    CompanyID = Column(Integer)
+    BranchID = Column(Integer)
+    WarehouseID = Column(Integer)
+    QuantityUpdate = Column(Integer)
+    QuantityBefore = Column(Integer)
+    QuantityAfter = Column(Integer)
+    TransactionDate = Column(DateTime, server_default=text("(getdate())"))
+    Reason = Column(Unicode(200, "Modern_Spanish_CI_AS"))
+    UserID = Column(Integer)
+
+    # Relaciones
+    items_: Mapped["Items"] = relationship("Items", back_populates="stockHistory")
+    warehouses_: Mapped["Warehouses"] = relationship(
+        "Warehouses", back_populates="stockHistory"
+    )
+    branches_: Mapped["Branches"] = relationship(
+        "Branches", back_populates="stockHistory"
+    )
+    companyData_: Mapped["CompanyData"] = relationship(
+        "CompanyData", back_populates="stockHistory"
+    )
+    users_: Mapped["Users"] = relationship("Users", back_populates="stockHistory")

--- a/app/models/tempstockentries.py
+++ b/app/models/tempstockentries.py
@@ -1,0 +1,79 @@
+# ========== TempStockEntries ===========
+# app/models/tempstockentries.py
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .branches import Branches
+    from .companydata import CompanyData
+    from .items import Items
+    from .users import Users
+    from .warehouses import Warehouses
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    DateTime,
+    Unicode,
+    Boolean,
+    Uuid,
+    Identity,
+    PrimaryKeyConstraint,
+    ForeignKeyConstraint,
+    text,
+)
+from sqlalchemy.orm import Mapped, relationship
+
+from app.db import Base
+
+
+class TempStockEntries(Base):
+    __tablename__ = "TempStockEntries"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["BranchID"], ["Branches.BranchID"], name="FK__TempStock__Branc__160F4887"
+        ),
+        ForeignKeyConstraint(
+            ["CompanyID"],
+            ["CompanyData.CompanyID"],
+            name="FK__TempStock__Compa__151B244E",
+        ),
+        ForeignKeyConstraint(
+            ["ItemID"], ["Items.ItemID"], name="FK__TempStock__ItemI__17F790F9"
+        ),
+        ForeignKeyConstraint(
+            ["UserID"], ["Users.UserID"], name="FK__TempStock__UserI__17036CC0"
+        ),
+        ForeignKeyConstraint(
+            ["WarehouseID"],
+            ["Warehouses.WarehouseID"],
+            name="FK__TempStock__Wareh__18EBB532",
+        ),
+        PrimaryKeyConstraint("TempStockEntryID", name="PK__TempStoc__6BCFA2A4F18BE300"),
+    )
+
+    TempStockEntryID = Column(Integer, Identity(start=1, increment=1), primary_key=True)
+    CompanyID = Column(Integer)
+    BranchID = Column(Integer)
+    UniqueID = Column(Uuid, server_default=text("(newid())"))
+    SessionID = Column(Unicode(100, "Modern_Spanish_CI_AS"))
+    UserID = Column(Integer)
+    ItemID = Column(Integer)
+    WarehouseID = Column(Integer)
+    Quantity = Column(Integer)
+    EntryDate = Column(DateTime, server_default=text("(getdate())"))
+    Reason = Column(Unicode(200, "Modern_Spanish_CI_AS"))
+    IsProcessed = Column(Boolean, server_default=text("((0))"))
+
+    # Relaciones
+    branches_: Mapped["Branches"] = relationship(
+        "Branches", back_populates="tempStockEntries"
+    )
+    companyData_: Mapped["CompanyData"] = relationship(
+        "CompanyData", back_populates="tempStockEntries"
+    )
+    items_: Mapped["Items"] = relationship("Items", back_populates="tempStockEntries")
+    users_: Mapped["Users"] = relationship("Users", back_populates="tempStockEntries")
+    warehouses_: Mapped["Warehouses"] = relationship(
+        "Warehouses", back_populates="tempStockEntries"
+    )


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for `StockHistory` and `TempStockEntries`
- create CRUD utilities, resolvers, mutations and schemas for the new models
- ensure imports in `schema.py` load successfully

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687c1b2adbc88323b1205b0980accc40