### PR TITLE
Add stock batch processing and search modals

### DIFF
--- a/app/graphql/crud/tempstockentries.py
+++ b/app/graphql/crud/tempstockentries.py
@@ -1,5 +1,6 @@
 ﻿# app/graphql/crud/tempstockentries.py
 from sqlalchemy.orm import Session
+import uuid
 from app.models.tempstockentries import TempStockEntries
 from app.graphql.schemas.tempstockentries import (
     TempStockEntriesCreate,
@@ -19,8 +20,27 @@ def get_tempstockentries_by_id(db: Session, entry_id: int):
     )
 
 
+def get_tempstockentries_by_session(db: Session, session_id: str):
+    """Obtener todas las entradas de stock temporales para un SessionID."""
+    return (
+        db.query(TempStockEntries)
+        .filter(TempStockEntries.SessionID == session_id)
+        .all()
+    )
+
+
 def create_tempstockentries(db: Session, data: TempStockEntriesCreate):
-    obj = TempStockEntries(**vars(data))
+    """Crear entrada temporal de stock manteniendo un UniqueID por sesion."""
+    # Buscar si ya existe un registro para esta sesion para reutilizar el UniqueID
+    existing = (
+        db.query(TempStockEntries)
+        .filter(TempStockEntries.SessionID == data.SessionID)
+        .first()
+    )
+
+    unique_id = existing.UniqueID if existing else uuid.uuid4()
+
+    obj = TempStockEntries(**vars(data), UniqueID=unique_id)
     db.add(obj)
     db.commit()
     db.refresh(obj)
@@ -44,3 +64,69 @@ def delete_tempstockentries(db: Session, entry_id: int):
         db.delete(obj)
         db.commit()
     return obj
+
+
+def process_stock_session(db: Session, session_id: str):
+    """Procesar todas las entradas de una sesión y actualizar stock."""
+    from app.models.itemstock import Itemstock
+    from app.models.stockhistory import StockHistory
+
+    entries = (
+        db.query(TempStockEntries)
+        .filter(TempStockEntries.SessionID == session_id, TempStockEntries.IsProcessed == False)
+        .all()
+    )
+
+    processed_records = []
+
+    for entry in entries:
+        # Buscar registro de stock
+        item_stock = (
+            db.query(Itemstock)
+            .filter(
+                Itemstock.ItemID == entry.ItemID,
+                Itemstock.WarehouseID == entry.WarehouseID,
+            )
+            .first()
+        )
+
+        if item_stock:
+            quantity_before = item_stock.Quantity or 0
+            setattr(
+                item_stock,
+                "Quantity",
+                (item_stock.Quantity or 0) + entry.Quantity,
+            )
+        else:
+            quantity_before = 0
+            item_stock = Itemstock(
+                ItemID=entry.ItemID,
+                WarehouseID=entry.WarehouseID,
+                CompanyID=entry.CompanyID,
+                BranchID=entry.BranchID,
+                Quantity=entry.Quantity,
+            )
+            db.add(item_stock)
+
+        history = StockHistory(
+            ItemID=entry.ItemID,
+            CompanyID=entry.CompanyID,
+            BranchID=entry.BranchID,
+            WarehouseID=entry.WarehouseID,
+            QuantityUpdate=entry.Quantity,
+            QuantityBefore=quantity_before,
+            QuantityAfter=(quantity_before + entry.Quantity),
+            Reason=entry.Reason,
+            UserID=entry.UserID,
+        )
+
+        db.add(history)
+        setattr(entry, "IsProcessed", True)
+        processed_records.append(history)
+
+    db.commit()
+
+    for record in processed_records:
+        db.refresh(record)
+
+    return processed_records

--- a/app/graphql/resolvers/tempstockentries.py
+++ b/app/graphql/resolvers/tempstockentries.py
@@ -5,6 +5,7 @@ from app.graphql.schemas.tempstockentries import TempStockEntriesInDB
 from app.graphql.crud.tempstockentries import (
     get_tempstockentries,
     get_tempstockentries_by_id,
+    get_tempstockentries_by_session,
 )
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
@@ -32,6 +33,18 @@ class TempstockentriesQuery:
         try:
             entry = get_tempstockentries_by_id(db, id)
             return obj_to_schema(TempStockEntriesInDB, entry) if entry else None
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def tempstockentries_by_session(
+        self, info: Info, sessionID: str
+    ) -> List[TempStockEntriesInDB]:
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            entries = get_tempstockentries_by_session(db, sessionID)
+            return list_to_schema(TempStockEntriesInDB, entries)
         finally:
             db_gen.close()
 

--- a/frontend/src/components/ItemConfirmationModal.jsx
+++ b/frontend/src/components/ItemConfirmationModal.jsx
@@ -1,5 +1,6 @@
 ﻿// frontend/src/components/ItemConfirmationModal.jsx
 import React, { useState, useEffect } from "react";
+import WarehouseSearchModal from "./WarehouseSearchModal";
 
 export default function ItemConfirmationModal({
     isOpen,
@@ -17,6 +18,7 @@ export default function ItemConfirmationModal({
     const [subtotal, setSubtotal] = useState(0);
     const [priceListId, setPriceListId] = useState(defaultPriceListId);
     const [warehouseId, setWarehouseId] = useState(defaultWarehouseId);
+    const [showWarehouseModal, setShowWarehouseModal] = useState(false);
 
     useEffect(() => {
         if (item) {
@@ -80,6 +82,7 @@ export default function ItemConfirmationModal({
     if (!isOpen || !item) return null;
 
     return (
+        <>
         <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 flex justify-center items-center">
             <div className="relative mx-auto p-6 border w-full max-w-lg shadow-lg rounded-md bg-white">
                 <div className="flex justify-between items-center pb-4 border-b">
@@ -198,19 +201,26 @@ export default function ItemConfirmationModal({
                             <label htmlFor="warehouseId" className="block text-sm font-medium text-gray-700 mb-1">
                                 Depósito
                             </label>
-                            <select
-                                id="warehouseId"
-                                value={warehouseId}
-                                onChange={(e) => setWarehouseId(e.target.value)}
-                                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
-                            >
-                                <option value="">Seleccionar...</option>
-                                {warehouses.map((w) => (
-                                    <option key={w.WarehouseID} value={w.WarehouseID}>
-                                        {w.Name}
-                                    </option>
-                                ))}
-                            </select>
+                            <div className="flex space-x-2 items-center">
+                                <select
+                                    id="warehouseId"
+                                    value={warehouseId}
+                                    onChange={(e) => setWarehouseId(e.target.value)}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                                >
+                                    <option value="">Seleccionar...</option>
+                                    {warehouses.map((w) => (
+                                        <option key={w.WarehouseID} value={w.WarehouseID}>
+                                            {w.Name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <button type="button" onClick={() => setShowWarehouseModal(true)} className="text-gray-400 hover:text-gray-600">
+                                    <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                                    </svg>
+                                </button>
+                            </div>
                         </div>
                     </div>
 
@@ -244,5 +254,16 @@ export default function ItemConfirmationModal({
                 </div>
             </div>
         </div>
+        {showWarehouseModal && (
+            <WarehouseSearchModal
+                isOpen={true}
+                onClose={() => setShowWarehouseModal(false)}
+                onSelect={(w) => {
+                    setWarehouseId(w.WarehouseID.toString());
+                    setShowWarehouseModal(false);
+                }}
+            />
+        )}
+        </>
     );
 }

--- a/frontend/src/components/WarehouseSearchModal.jsx
+++ b/frontend/src/components/WarehouseSearchModal.jsx
@@ -1,0 +1,95 @@
+// frontend/src/components/WarehouseSearchModal.jsx
+import React, { useEffect, useState } from "react";
+import { warehouseOperations } from "../utils/graphqlClient";
+import TableFilters from "./TableFilters";
+
+export default function WarehouseSearchModal({ isOpen, onClose, onSelect }) {
+    const [warehouses, setWarehouses] = useState([]);
+    const [filtered, setFiltered] = useState([]);
+    const [query, setQuery] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [showFilters, setShowFilters] = useState(false);
+
+    useEffect(() => {
+        async function loadData() {
+            setLoading(true);
+            try {
+                const data = await warehouseOperations.getAllWarehouses();
+                setWarehouses(data);
+                setFiltered(data);
+            } catch (err) {
+                console.error("Error fetching warehouses:", err);
+                setWarehouses([]);
+                setFiltered([]);
+            }
+            setLoading(false);
+        }
+        if (isOpen) {
+            setQuery("");
+            setShowFilters(false);
+            loadData();
+        }
+    }, [isOpen]);
+
+    if (!isOpen) return null;
+
+    const list = filtered.filter(w => (w.Name || "").toLowerCase().includes(query.toLowerCase()));
+
+    return (
+        <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 flex justify-center items-start pt-10">
+            <div className="relative mx-auto p-5 border w-full max-w-xl shadow-lg rounded-md bg-white space-y-4">
+                <div className="flex justify-between items-center pb-3 border-b">
+                    <h3 className="text-xl font-semibold text-gray-700">Buscar Depósito</h3>
+                    <button onClick={onClose} className="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+                <div className="flex space-x-2">
+                    <input type="text" value={query} onChange={e => setQuery(e.target.value)} className="flex-1 border rounded px-3 py-2" placeholder="Nombre..." />
+                    <button type="button" onClick={() => setShowFilters(!showFilters)} className="px-3 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 text-sm">
+                        {showFilters ? "Ocultar Filtros" : "Mostrar Filtros"}
+                    </button>
+                </div>
+                {showFilters && (
+                    <div className="border border-gray-200 rounded-md p-4 bg-gray-50">
+                        <TableFilters modelName="warehouses" data={warehouses} onFilterChange={setFiltered} />
+                    </div>
+                )}
+                {loading ? (
+                    <div className="flex justify-center py-8">Cargando...</div>
+                ) : (
+                    <div className="max-h-80 overflow-y-auto">
+                        <table className="min-w-full divide-y divide-gray-200 text-sm">
+                            <thead className="bg-gray-50 sticky top-0">
+                                <tr>
+                                    <th className="px-4 py-2 text-left">ID</th>
+                                    <th className="px-4 py-2 text-left">Nombre</th>
+                                    <th className="px-4 py-2"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {list.length > 0 ? (
+                                    list.map(w => (
+                                        <tr key={w.WarehouseID} className="hover:bg-gray-50" onDoubleClick={() => { onSelect(w); onClose(); }}>
+                                            <td className="px-4 py-2">{w.WarehouseID}</td>
+                                            <td className="px-4 py-2">{w.Name}</td>
+                                            <td className="px-4 py-2">
+                                                <button onClick={() => { onSelect(w); onClose(); }} className="text-blue-600 hover:underline">Seleccionar</button>
+                                            </td>
+                                        </tr>
+                                    ))
+                                ) : (
+                                    <tr>
+                                        <td colSpan="3" className="px-4 py-8 text-center text-gray-500">No se encontraron depósitos</td>
+                                    </tr>
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- keep same UniqueID per session and process batches on backend
- expose query by session and mutation to process stock
- add WarehouseSearchModal component
- enhance StockEntry with dropdown search modals and confirmation modal
- support warehouse lookup from ItemConfirmationModal
- fix stock processing assignments to avoid pyright errors

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687edd83cf548323af492fc6fc0bafd6