### PR TITLE
Add cashbox GraphQL operations

### DIFF
--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -944,6 +944,88 @@ export const MUTATIONS = {
         }
     `,
 
+    // CAJAS
+    CREATE_CASHBOX: `
+        mutation CreateCashbox($input: CashBoxesCreate!) {
+            createCashbox(data: $input) {
+                CashBoxID
+                CompanyID
+                BranchID
+                Name
+                Description
+                IsActive
+                OpenDate
+                CloseDate
+                InitialBalance
+                CurrentBalance
+                UserID
+                Notes
+            }
+        }
+    `,
+    UPDATE_CASHBOX: `
+        mutation UpdateCashbox($cashBoxID: Int!, $input: CashBoxesUpdate!) {
+            updateCashbox(cashBoxID: $cashBoxID, data: $input) {
+                CashBoxID
+                CompanyID
+                BranchID
+                Name
+                Description
+                IsActive
+                OpenDate
+                CloseDate
+                InitialBalance
+                CurrentBalance
+                UserID
+                Notes
+            }
+        }
+    `,
+    DELETE_CASHBOX: `
+        mutation DeleteCashbox($cashBoxID: Int!) {
+            deleteCashbox(cashBoxID: $cashBoxID)
+        }
+    `,
+
+    // MOVIMIENTOS DE CAJA
+    CREATE_CASHBOXMOVEMENT: `
+        mutation CreateCashboxmovement($input: CashBoxMovementsCreate!) {
+            createCashboxmovement(data: $input) {
+                CashBoxMovementID
+                CashBoxID
+                CompanyID
+                BranchID
+                MovementDate
+                Amount
+                MovementType
+                Description
+                UserID
+                Notes
+            }
+        }
+    `,
+    UPDATE_CASHBOXMOVEMENT: `
+        mutation UpdateCashboxmovement($movementID: Int!, $input: CashBoxMovementsUpdate!) {
+            updateCashboxmovement(movementID: $movementID, data: $input) {
+                CashBoxMovementID
+                CashBoxID
+                CompanyID
+                BranchID
+                MovementDate
+                Amount
+                MovementType
+                Description
+                UserID
+                Notes
+            }
+        }
+    `,
+    DELETE_CASHBOXMOVEMENT: `
+        mutation DeleteCashboxmovement($movementID: Int!) {
+            deleteCashboxmovement(movementID: $movementID)
+        }
+    `,
+
     // ====== TEMPORARY STOCK ENTRIES ======
     CREATE_TEMPSTOCKENTRY: `
         mutation CreateTempstockhistorydetail($input: TempStockHistoryDetailsCreate!) {

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1658,4 +1658,50 @@ export const branchOperations = {
     }
 };
 
+export const cashboxOperations = {
+    async getAllCashboxes() {
+        const data = await graphqlClient.query(QUERIES.GET_ALL_CASHBOXES);
+        return data.allCashboxes || [];
+    },
+    async getCashboxById(id) {
+        const data = await graphqlClient.query(QUERIES.GET_CASHBOX_BY_ID, { id });
+        return data.cashboxesById;
+    },
+    async createCashbox(input) {
+        const data = await graphqlClient.mutation(MUTATIONS.CREATE_CASHBOX, { input });
+        return data.createCashbox;
+    },
+    async updateCashbox(id, input) {
+        const data = await graphqlClient.mutation(MUTATIONS.UPDATE_CASHBOX, { cashBoxID: id, input });
+        return data.updateCashbox;
+    },
+    async deleteCashbox(id) {
+        const data = await graphqlClient.mutation(MUTATIONS.DELETE_CASHBOX, { cashBoxID: id });
+        return data.deleteCashbox;
+    }
+};
+
+export const cashboxMovementOperations = {
+    async getAllCashboxmovements() {
+        const data = await graphqlClient.query(QUERIES.GET_ALL_CASHBOXMOVEMENTS);
+        return data.allCashboxmovements || [];
+    },
+    async getCashboxmovementById(id) {
+        const data = await graphqlClient.query(QUERIES.GET_CASHBOXMOVEMENT_BY_ID, { id });
+        return data.cashboxmovementsById;
+    },
+    async createCashboxmovement(input) {
+        const data = await graphqlClient.mutation(MUTATIONS.CREATE_CASHBOXMOVEMENT, { input });
+        return data.createCashboxmovement;
+    },
+    async updateCashboxmovement(id, input) {
+        const data = await graphqlClient.mutation(MUTATIONS.UPDATE_CASHBOXMOVEMENT, { movementID: id, input });
+        return data.updateCashboxmovement;
+    },
+    async deleteCashboxmovement(id) {
+        const data = await graphqlClient.mutation(MUTATIONS.DELETE_CASHBOXMOVEMENT, { movementID: id });
+        return data.deleteCashboxmovement;
+    }
+};
+
 export { afipOperations };

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -893,6 +893,78 @@ export const QUERIES = {
         }
     `,
 
+    // CAJAS
+    GET_ALL_CASHBOXES: `
+        query GetAllCashboxes {
+            allCashboxes {
+                CashBoxID
+                CompanyID
+                BranchID
+                Name
+                Description
+                IsActive
+                OpenDate
+                CloseDate
+                InitialBalance
+                CurrentBalance
+                UserID
+                Notes
+            }
+        }
+    `,
+    GET_CASHBOX_BY_ID: `
+        query GetCashboxById($id: Int!) {
+            cashboxesById(id: $id) {
+                CashBoxID
+                CompanyID
+                BranchID
+                Name
+                Description
+                IsActive
+                OpenDate
+                CloseDate
+                InitialBalance
+                CurrentBalance
+                UserID
+                Notes
+            }
+        }
+    `,
+
+    // MOVIMIENTOS DE CAJA
+    GET_ALL_CASHBOXMOVEMENTS: `
+        query GetAllCashboxmovements {
+            allCashboxmovements {
+                CashBoxMovementID
+                CashBoxID
+                CompanyID
+                BranchID
+                MovementDate
+                Amount
+                MovementType
+                Description
+                UserID
+                Notes
+            }
+        }
+    `,
+    GET_CASHBOXMOVEMENT_BY_ID: `
+        query GetCashboxmovementById($id: Int!) {
+            cashboxmovementsById(id: $id) {
+                CashBoxMovementID
+                CashBoxID
+                CompanyID
+                BranchID
+                MovementDate
+                Amount
+                MovementType
+                Description
+                UserID
+                Notes
+            }
+        }
+    `,
+
     // BÚSQUEDA DE CLIENTES
     SEARCH_CLIENTS: `
         query SearchClients($searchTerm: String!, $isActive: Boolean) {


### PR DESCRIPTION
## Summary
- add queries for cashboxes and movements
- add placeholder mutations
- expose cashbox operations in client utilities

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f4c88019c83238bf933f6133e8ef5