### PR TITLE
Fix document type references in frontend

### DIFF
--- a/frontend/src/components/TableFilters.jsx
+++ b/frontend/src/components/TableFilters.jsx
@@ -16,7 +16,7 @@ const pluralMap = {
     Province: "Provinces",
     Branch: "Branches",
     Company: "Companydata",
-    DocType: "Doctypes",
+    DocType: "Documenttypes",
     DocumentType: "Documenttypes",
     ItemCategory: "Itemcategories",
     ItemSubcategory: "Itemsubcategories",

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -111,7 +111,7 @@ export const clientOperations = {
         try {
             const data = await graphqlClient.query(QUERIES.GET_CLIENT_FORM_DATA);
             return {
-                documentTypes: data.docTypes || [],
+                documentTypes: data.documentTypes || [],
                 countries: data.countries || [],
                 provinces: data.provinces || [],
                 priceLists: data.priceLists?.filter(pl => pl.IsActive) || [],
@@ -201,7 +201,7 @@ export const supplierOperations = {
         try {
             const data = await graphqlClient.query(QUERIES.GET_SUPPLIER_FORM_DATA);
             return {
-                documentTypes: data.docTypes || [],
+                documentTypes: data.documentTypes || [],
                 countries: data.countries || [],
                 provinces: data.provinces || []
             };

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -275,8 +275,8 @@ export const QUERIES = {
     // COMBOS PARA FORMULARIOS
     GET_CLIENT_FORM_DATA: `
         query GetClientFormData {
-            docTypes: allDoctypes {
-                DocTypeID
+            documentTypes: allDocumenttypes {
+                DocumentTypeID
                 Name
             }
             countries: allCountries {
@@ -305,8 +305,8 @@ export const QUERIES = {
     // FORMULARIO DE PROVEEDORES
     GET_SUPPLIER_FORM_DATA: `
         query GetSupplierFormData {
-            docTypes: allDoctypes {
-                DocTypeID
+            documentTypes: allDocumenttypes {
+                DocumentTypeID
                 Name
             }
             countries: allCountries {


### PR DESCRIPTION
## Summary
- update queries to fetch `DocumentTypes`
- update operations to expect `documentTypes`
- map `DocType` to `Documenttypes` in table filters

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f5394afd48323b1d30ecc5f0844d7