### PR TITLE
Update frontend forms with company fields

### DIFF
--- a/frontend/src/components/CarBrandSearchModal.jsx
+++ b/frontend/src/components/CarBrandSearchModal.jsx
@@ -91,6 +91,7 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
             <thead className="bg-gray-50 sticky top-0">
               <tr>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Compañía</th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nombre</th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Acción</th>
               </tr>
@@ -107,6 +108,7 @@ export default function CarBrandSearchModal({ isOpen, onClose, onBrandSelect }) 
                     }}
                   >
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">{b.CarBrandID}</td>
+                    <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">{b.CompanyID}</td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-700">{b.Name}</td>
                     <td className="px-4 py-3 whitespace-nowrap text-sm font-medium">
                       <button

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -629,6 +629,7 @@ export const carModelOperations = {
 
 function sanitizeCarPayload(data) {
     const allowed = [
+        'CompanyID',
         'CarModelID',
         'ClientID',
         'LicensePlate',
@@ -661,6 +662,7 @@ export const carOperations = {
         try {
             const data = await graphqlClient.query(QUERIES.GET_CAR_FORM_DATA);
             return {
+                companies: data.companies || [],
                 carBrands: data.carBrands || [],
                 carModels: data.carModels || [],
                 clients: data.clients || [],

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -324,6 +324,10 @@ export const QUERIES = {
     // FORMULARIO DE AUTOS
     GET_CAR_FORM_DATA: `
         query GetCarFormData {
+            companies: allCompanydata {
+                CompanyID
+                Name
+            }
             carBrands: allCarbrands {
                 CarBrandID
                 Name
@@ -515,6 +519,7 @@ export const QUERIES = {
         query GetAllBrands {
             allBrands {
                 BrandID
+                CompanyID
                 Name
                 IsActive
             }
@@ -524,6 +529,7 @@ export const QUERIES = {
         query GetBrandById($id: Int!) {
             brandsById(id: $id) {
                 BrandID
+                CompanyID
                 Name
                 IsActive
             }
@@ -586,6 +592,7 @@ export const QUERIES = {
         query GetAllCarBrands {
             allCarbrands {
                 CarBrandID
+                CompanyID
                 Name
             }
         }
@@ -594,6 +601,7 @@ export const QUERIES = {
         query GetCarBrandById($id: Int!) {
             carbrandsById(id: $id) {
                 CarBrandID
+                CompanyID
                 Name
             }
         }
@@ -656,6 +664,7 @@ export const QUERIES = {
         query GetCarById($id: Int!) {
             carsById(id: $id) {
                 CarID
+                CompanyID
                 LicensePlate
                 Year
                 CarModelID


### PR DESCRIPTION
## Summary
- add CompanyID to brand and carbrand queries
- include company lists in car form queries and operations
- allow selecting company in car, brand and car brand creation forms
- show company column in car brand search modal
- sanitize CompanyID in car mutation payloads

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f57a2fe548323aa23322d4f289a35