### PR TITLE
Fix SysOrderStatus model name

### DIFF
--- a/app/models/orders.py
+++ b/app/models/orders.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .companydata import CompanyData
     from .discounts import Discounts
     from .sysdocumenttypes import SysDocumentTypes
-    from .sysorderstatus import sysOrderStatus  # <--- corregido acá
+    from .sysorderstatus import SysOrderStatus  # <--- corregido acá
     from .pricelists import PriceLists
     from .saleconditions import SaleConditions
     from .servicetype import ServiceType
@@ -37,7 +37,7 @@ class Orders(Base):
         ForeignKeyConstraint(['CompanyID'], ['CompanyData.CompanyID'], name='FK__Orders__CompanyI__02084FDA'),
         ForeignKeyConstraint(['DiscountID'], ['Discounts.DiscountID'], name='FK__Orders__Discount__04E4BC85'),
         ForeignKeyConstraint(['DocumentID'], ['SysDocumentTypes.DocumentTypeID'], name='FK__Orders__SysDocume__06CD04F7'),
-        ForeignKeyConstraint(['OrderStatusID'], ['sysOrderStatus.OrderstatusID'], name='FK_Orders_OrderStatus'),  # <--- corregido acá
+        ForeignKeyConstraint(['OrderStatusID'], ['SysOrderStatus.OrderstatusID'], name='FK_Orders_OrderStatus'),  # <--- corregido acá
         ForeignKeyConstraint(['PriceListID'], ['PriceLists.PriceListID'], name='FK__Orders__PriceLis__08B54D69'),
         ForeignKeyConstraint(['SaleConditionID'], ['SaleConditions.SaleConditionID'], name='FK__Orders__SaleCond__03F0984C'),
         ForeignKeyConstraint(['ServiceTypeID'], ['ServiceType.ServiceTypeID'], name='FK_Orders_ServiceType'),        
@@ -78,7 +78,7 @@ class Orders(Base):
     companyData_: Mapped['CompanyData'] = relationship('CompanyData', back_populates='orders')
     discounts_: Mapped['Discounts'] = relationship('Discounts', back_populates='orders')
     sysDocumentTypes_: Mapped['SysDocumentTypes'] = relationship('SysDocumentTypes', back_populates='orders')
-    orderStatus_: Mapped['sysOrderStatus'] = relationship('sysOrderStatus', foreign_keys=[OrderStatusID], back_populates='orders')   # <--- corregido acá
+    orderStatus_: Mapped['SysOrderStatus'] = relationship('SysOrderStatus', foreign_keys=[OrderStatusID], back_populates='orders')   # <--- corregido acá
     priceLists_: Mapped['PriceLists'] = relationship('PriceLists', back_populates='orders')
     saleConditions_: Mapped['SaleConditions'] = relationship('SaleConditions', back_populates='orders')
     serviceType_: Mapped[Optional['ServiceType']] = relationship('ServiceType', back_populates='orders')    

--- a/app/models/sysorderstatus.py
+++ b/app/models/sysorderstatus.py
@@ -1,4 +1,4 @@
-# ========== sysOrderStatus ===========
+# ========== SysOrderStatus ===========
 # app/models/sysorderstatus.py
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Mapped, relationship
 from app.db import Base
 
 
-class sysOrderStatus(Base):  # <--- corregido nombre de clase
+class SysOrderStatus(Base):  # <--- corregido nombre de clase
     __tablename__ = 'sysOrderStatus'
     __table_args__ = (
         PrimaryKeyConstraint('OrderstatusID', name='PK__OrderSta__BC674F4170B3E561'),


### PR DESCRIPTION
## Summary
- correct class name in SysOrderStatus model
- update Orders model to match new name

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880ff95637083238a9da7522e933b29