### PR TITLE
Update for composite foreign keys

### DIFF
--- a/app/graphql/crud/provinces.py
+++ b/app/graphql/crud/provinces.py
@@ -13,8 +13,16 @@ def get_provinces_by_country(db: Session, country_id: int):
     return db.query(Provinces).filter(Provinces.CountryID == country_id).all()
 
 
-def get_provinces_by_id(db: Session, provinceid: int):
-    return db.query(Provinces).filter(Provinces.ProvinceID == provinceid).first()
+def get_provinces_by_id(db: Session, country_id: int, province_id: int):
+    """Retrieve a province by its composite key."""
+    return (
+        db.query(Provinces)
+        .filter(
+            Provinces.CountryID == country_id,
+            Provinces.ProvinceID == province_id,
+        )
+        .first()
+    )
 
 
 def create_provinces(db: Session, data: ProvincesCreate):
@@ -25,8 +33,8 @@ def create_provinces(db: Session, data: ProvincesCreate):
     return obj
 
 
-def update_provinces(db: Session, provinceid: int, data: ProvincesUpdate):
-    obj = get_provinces_by_id(db, provinceid)
+def update_provinces(db: Session, country_id: int, province_id: int, data: ProvincesUpdate):
+    obj = get_provinces_by_id(db, country_id, province_id)
     if obj:
         for k, v in vars(data).items():
             if v is not None:
@@ -36,8 +44,8 @@ def update_provinces(db: Session, provinceid: int, data: ProvincesUpdate):
     return obj
 
 
-def delete_provinces(db: Session, provinceid: int):
-    obj = get_provinces_by_id(db, provinceid)
+def delete_provinces(db: Session, country_id: int, province_id: int):
+    obj = get_provinces_by_id(db, country_id, province_id)
     if obj:
         db.delete(obj)
         db.commit()

--- a/app/graphql/mutations/branches.py
+++ b/app/graphql/mutations/branches.py
@@ -20,21 +20,23 @@ class BranchesMutations:
             db_gen.close()
 
     @strawberry.mutation
-    def update_branch(self, info: Info, branchID: int, data: BranchesUpdate) -> Optional[BranchesInDB]:
+    def update_branch(
+        self, info: Info, companyID: int, branchID: int, data: BranchesUpdate
+    ) -> Optional[BranchesInDB]:
         db_gen = get_db()
         db = next(db_gen)
         try:
-            updated = update_branches(db, branchID, data)
+            updated = update_branches(db, companyID, branchID, data)
             return obj_to_schema(BranchesInDB, updated) if updated else None
         finally:
             db_gen.close()
 
     @strawberry.mutation
-    def delete_branch(self, info: Info, branchID: int) -> bool:
+    def delete_branch(self, info: Info, companyID: int, branchID: int) -> bool:
         db_gen = get_db()
         db = next(db_gen)
         try:
-            deleted = delete_branches(db, branchID)
+            deleted = delete_branches(db, companyID, branchID)
             return deleted is not None
         finally:
             db_gen.close()

--- a/app/graphql/resolvers/provinces.py
+++ b/app/graphql/resolvers/provinces.py
@@ -25,11 +25,13 @@ class ProvincesQuery:
             db_gen.close()
 
     @strawberry.field
-    def provinces_by_id(self, info: Info, id: int) -> Optional[ProvincesInDB]:
+    def provinces_by_id(
+        self, info: Info, countryID: int, provinceID: int
+    ) -> Optional[ProvincesInDB]:
         db_gen = get_db()
         db = next(db_gen)
         try:
-            province = get_provinces_by_id(db, id)
+            province = get_provinces_by_id(db, countryID, provinceID)
             return obj_to_schema(ProvincesInDB, province) if province else None
         finally:
             db_gen.close()

--- a/app/models/branches.py
+++ b/app/models/branches.py
@@ -26,17 +26,13 @@ class Branches(Base):
     __table_args__ = (
         ForeignKeyConstraint(
             ["CompanyID"], ["CompanyData.CompanyID"],
-            name="FK_Branches_CompanyData"
+            name="FK_Branches_CompanyData",
         ),
-        PrimaryKeyConstraint(
-            "CompanyID",
-            "BranchID",
-            name="PK_Branches"
-        ),
+        PrimaryKeyConstraint("CompanyID", "BranchID", name="PK_Branches"),
     )
 
+    CompanyID = Column(Integer, primary_key=True)
     BranchID = Column(Integer, Identity(start=1, increment=1), primary_key=True)
-    CompanyID = Column(Integer)
     Name = Column(Unicode(100, 'Modern_Spanish_CI_AS'))
     Address = Column(Unicode(200, 'Modern_Spanish_CI_AS'))
     Phone = Column(Unicode(20, 'Modern_Spanish_CI_AS'))

--- a/app/models/provinces.py
+++ b/app/models/provinces.py
@@ -20,14 +20,14 @@ class Provinces(Base):
     __tablename__ = 'Provinces'
     __table_args__ = (
         ForeignKeyConstraint(
-            ['CountryID'], ['Countries.CountryID'],
-            name='FK__Provinces__Count__403A8C7D'
+            ["CountryID"], ["Countries.CountryID"],
+            name="FK__Provinces__Count__403A8C7D",
         ),
-        PrimaryKeyConstraint('CountryID', 'ProvinceID', name='PK_Provinces')
+        PrimaryKeyConstraint("CountryID", "ProvinceID", name="PK_Provinces"),
     )
 
+    CountryID = Column(Integer, primary_key=True)
     ProvinceID = Column(Integer, Identity(start=1, increment=1), primary_key=True)
-    CountryID = Column(Integer)
     Name = Column(Unicode(100, 'Modern_Spanish_CI_AS'))
 
     # Relaciones

--- a/frontend/src/pages/BranchCreate.jsx
+++ b/frontend/src/pages/BranchCreate.jsx
@@ -47,7 +47,11 @@ export default function BranchCreate({ onClose, onSave, branch: initialBranch = 
             };
             let result;
             if (isEdit) {
-                result = await branchOperations.updateBranch(initialBranch.BranchID, payload);
+                result = await branchOperations.updateBranch(
+                    initialBranch.CompanyID,
+                    initialBranch.BranchID,
+                    payload
+                );
             } else {
                 result = await branchOperations.createBranch(payload);
             }

--- a/frontend/src/pages/Branches.jsx
+++ b/frontend/src/pages/Branches.jsx
@@ -72,10 +72,10 @@ export default function Branches() {
         );
     };
 
-    const handleDelete = async (id) => {
+    const handleDelete = async (id, companyID) => {
         if (!confirm('¿Borrar sucursal?')) return;
         try {
-            await branchOperations.deleteBranch(id);
+            await branchOperations.deleteBranch(companyID, id);
             loadBranches();
         } catch (err) {
             alert('Error al borrar sucursal: ' + err.message);
@@ -117,7 +117,7 @@ export default function Branches() {
                             <p className="text-sm mb-2">Empresa ID: {br.CompanyID}</p>
                             <div className="flex space-x-2">
                                 <button onClick={() => handleEdit(br)} className="mt-2 px-3 py-1 bg-gray-100 text-sm rounded hover:bg-gray-200">Editar</button>
-                                <button onClick={() => handleDelete(br.BranchID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
+                                <button onClick={() => handleDelete(br.BranchID, br.CompanyID)} className="mt-2 px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700">Eliminar</button>
                             </div>
                         </div>
                     ))}

--- a/frontend/src/utils/graphql/mutations.js
+++ b/frontend/src/utils/graphql/mutations.js
@@ -661,8 +661,8 @@ export const MUTATIONS = {
         }
     `,
     UPDATE_BRANCH: `
-        mutation UpdateBranch($branchID: Int!, $input: BranchesUpdate!) {
-            updateBranch(branchID: $branchID, data: $input) {
+        mutation UpdateBranch($companyID: Int!, $branchID: Int!, $input: BranchesUpdate!) {
+            updateBranch(companyID: $companyID, branchID: $branchID, data: $input) {
                 BranchID
                 CompanyID
                 Name
@@ -670,8 +670,8 @@ export const MUTATIONS = {
         }
     `,
     DELETE_BRANCH: `
-        mutation DeleteBranch($branchID: Int!) {
-            deleteBranch(branchID: $branchID)
+        mutation DeleteBranch($companyID: Int!, $branchID: Int!) {
+            deleteBranch(companyID: $companyID, branchID: $branchID)
         }
     `,
 

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -1646,9 +1646,13 @@ export const branchOperations = {
         }
     },
 
-    async updateBranch(id, dataInput) {
+    async updateBranch(companyID, id, dataInput) {
         try {
-            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_BRANCH, { branchID: id, input: dataInput });
+            const data = await graphqlClient.mutation(MUTATIONS.UPDATE_BRANCH, {
+                companyID,
+                branchID: id,
+                input: dataInput,
+            });
             return data.updateBranch;
         } catch (error) {
             console.error("Error actualizando sucursal:", error);
@@ -1656,9 +1660,12 @@ export const branchOperations = {
         }
     },
 
-    async deleteBranch(id) {
+    async deleteBranch(companyID, id) {
         try {
-            const data = await graphqlClient.mutation(MUTATIONS.DELETE_BRANCH, { branchID: id });
+            const data = await graphqlClient.mutation(MUTATIONS.DELETE_BRANCH, {
+                companyID,
+                branchID: id,
+            });
             return data.deleteBranch;
         } catch (error) {
             console.error("Error eliminando sucursal:", error);


### PR DESCRIPTION
## Summary
- adjust province CRUD to use (CountryID, ProvinceID)
- update province resolver to expect composite key
- require CompanyID in branch mutations
- pass CompanyID from frontend when updating or deleting branches
- fix composite key declarations in Branches and Provinces models

## Testing
- `npm run lint`
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688115dc849083239bb442b72e10bcef