### PR TITLE
Fix join conditions and overlapping warnings

### DIFF
--- a/app/models/clients.py
+++ b/app/models/clients.py
@@ -50,10 +50,19 @@ class Clients(Base):
     PostalCode = Column(Unicode(20, 'Modern_Spanish_CI_AS'))
 
     # Relaciones
-    countries_: Mapped['Countries'] = relationship('Countries', back_populates='clients')
+    countries_: Mapped['Countries'] = relationship(
+        'Countries',
+        back_populates='clients',
+        primaryjoin='Clients.CountryID == Countries.CountryID',
+        foreign_keys='Clients.CountryID',
+    )
     docTypes_: Mapped['SysDocTypes'] = relationship('SysDocTypes', back_populates='clients')
     pricelists_: Mapped['PriceLists'] = relationship('PriceLists', back_populates='clients')
-    provinces_: Mapped['Provinces'] = relationship('Provinces', back_populates='clients')
+    provinces_: Mapped['Provinces'] = relationship(
+        'Provinces',
+        back_populates='clients',
+        overlaps='countries_',
+    )
     vendors_: Mapped['Vendors'] = relationship('Vendors', back_populates='clients')
     accountBalances: Mapped[List['AccountBalances']] = relationship('AccountBalances', back_populates='clients_')
     cars: Mapped[List['Cars']] = relationship('Cars', back_populates='clients_')

--- a/app/models/companydata.py
+++ b/app/models/companydata.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 from typing import List
 
 from sqlalchemy import Column, Integer, Unicode, Date, LargeBinary, Identity, PrimaryKeyConstraint
-from sqlalchemy.orm import Mapped, relationship
+from sqlalchemy.orm import Mapped, relationship, foreign
 
 
 from app.db import Base
@@ -41,9 +41,23 @@ class CompanyData(Base):
 
     # Relaciones
     branches: Mapped[List['Branches']] = relationship('Branches', back_populates='companyData_')
-    documents: Mapped[List['Documents']] = relationship('Documents', back_populates='companyData_')
-    userAccess: Mapped[List['UserAccess']] = relationship('UserAccess', back_populates='companyData_')
-    items: Mapped[List['Items']] = relationship('Items', back_populates='companyData_')
+    documents: Mapped[List['Documents']] = relationship(
+        'Documents',
+        back_populates='companyData_',
+        primaryjoin='CompanyData.CompanyID == foreign(Documents.CompanyID)',
+        foreign_keys='Documents.CompanyID',
+        overlaps='documents',
+    )
+    userAccess: Mapped[List['UserAccess']] = relationship(
+        'UserAccess', back_populates='companyData_', overlaps='userAccess'
+    )
+    items: Mapped[List['Items']] = relationship(
+        'Items',
+        back_populates='companyData_',
+        primaryjoin='CompanyData.CompanyID == foreign(Items.CompanyID)',
+        foreign_keys='Items.CompanyID',
+        overlaps='branches',
+    )
     itemstock: Mapped[List['Itemstock']] = relationship('Itemstock', back_populates='companyData_')
     orders: Mapped[List['Orders']] = relationship('Orders', back_populates='companyData_')
     stockHistory: Mapped[List['StockHistory']] = relationship('StockHistory', back_populates='companyData_')

--- a/app/models/countries.py
+++ b/app/models/countries.py
@@ -27,5 +27,15 @@ class Countries(Base):
 
     # Relaciones
     provinces: Mapped[List['Provinces']] = relationship('Provinces', back_populates='countries_')
-    clients: Mapped[List['Clients']] = relationship('Clients', back_populates='countries_')
-    suppliers: Mapped[List['Suppliers']] = relationship('Suppliers', back_populates='countries_')
+    clients: Mapped[List['Clients']] = relationship(
+        'Clients',
+        back_populates='countries_',
+        primaryjoin='Clients.CountryID == Countries.CountryID',
+        foreign_keys='Clients.CountryID',
+    )
+    suppliers: Mapped[List['Suppliers']] = relationship(
+        'Suppliers',
+        back_populates='countries_',
+        primaryjoin='Suppliers.CountryID == Countries.CountryID',
+        foreign_keys='Suppliers.CountryID',
+    )

--- a/app/models/documents.py
+++ b/app/models/documents.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 from typing import List
 
 from sqlalchemy import Column, Integer, Unicode, Boolean, LargeBinary, Identity, PrimaryKeyConstraint, ForeignKeyConstraint, text
-from sqlalchemy.orm import Mapped, relationship
+from sqlalchemy.orm import Mapped, relationship, foreign
 #from .branches import Branches
 #from .companydata import CompanyData    
 #from .documenttypes import DocumentTypes    
@@ -49,5 +49,11 @@ class Documents(Base):
 
     # Relaciones
     branches_: Mapped['Branches'] = relationship('Branches', back_populates='documents')
-    companyData_: Mapped['CompanyData'] = relationship('CompanyData', back_populates='documents')
+    companyData_: Mapped['CompanyData'] = relationship(
+        'CompanyData',
+        back_populates='documents',
+        primaryjoin='foreign(Documents.CompanyID) == CompanyData.CompanyID',
+        foreign_keys='Documents.CompanyID',
+        overlaps='branches_',
+    )
     sysDocumentTypes_: Mapped['SysDocumentTypes'] = relationship('SysDocumentTypes', back_populates='documents')

--- a/app/models/items.py
+++ b/app/models/items.py
@@ -62,7 +62,13 @@ class Items(Base):
     # Relaciones
     branches_: Mapped[Branches] = relationship('Branches', back_populates='items')
     brands_: Mapped[Brands] = relationship('Brands', back_populates='items')
-    companyData_: Mapped[CompanyData] = relationship('CompanyData', back_populates='items')
+    companyData_: Mapped[CompanyData] = relationship(
+        'CompanyData',
+        back_populates='items',
+        primaryjoin='foreign(Items.CompanyID) == CompanyData.CompanyID',
+        foreign_keys='Items.CompanyID',
+        overlaps='branches',
+    )
     itemCategories_: Mapped[ItemCategories] = relationship('ItemCategories', back_populates='items')
     itemSubcategories_: Mapped[ItemSubcategories] = relationship('ItemSubcategories', back_populates='items')
     suppliers_: Mapped[Suppliers] = relationship('Suppliers', back_populates='items')

--- a/app/models/suppliers.py
+++ b/app/models/suppliers.py
@@ -47,7 +47,12 @@ class Suppliers(Base):
     PostalCode = Column(Unicode(20, 'Modern_Spanish_CI_AS'))
 
     # Relaciones
-    countries_: Mapped['Countries'] = relationship('Countries', back_populates='suppliers')
+    countries_: Mapped['Countries'] = relationship(
+        'Countries',
+        back_populates='suppliers',
+        primaryjoin='Suppliers.CountryID == Countries.CountryID',
+        foreign_keys='Suppliers.CountryID',
+    )
     docTypes_: Mapped['SysDocTypes'] = relationship('SysDocTypes', back_populates='suppliers')
     provinces_: Mapped['Provinces'] = relationship('Provinces', back_populates='suppliers')
     accountBalances: Mapped[List['AccountBalances']] = relationship('AccountBalances', back_populates='suppliers_')


### PR DESCRIPTION
## Summary
- handle overlapping relationships in `CompanyData`
- give explicit join condition for items
- mirror join condition in `Items` model

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68811fd7c5e4832398e79d8814b79e26