### PR TITLE
Fix order status foreign key

### DIFF
--- a/app/models/orders.py
+++ b/app/models/orders.py
@@ -41,7 +41,7 @@ class Orders(Base):
         ForeignKeyConstraint(['CompanyID'], ['CompanyData.CompanyID'], name='FK__Orders__CompanyI__02084FDA'),
         ForeignKeyConstraint(['DiscountID'], ['Discounts.DiscountID'], name='FK__Orders__Discount__04E4BC85'),
         ForeignKeyConstraint(['DocumentID'], ['SysDocumentTypes.DocumentTypeID'], name='FK__Orders__SysDocume__06CD04F7'),
-        ForeignKeyConstraint(['OrderStatusID'], ['SysOrderStatus.OrderstatusID'], name='FK_Orders_OrderStatus'),  # <--- corregido acá
+        ForeignKeyConstraint(['OrderStatusID'], ['SysOrderStatus.OrderStatusID'], name='FK_Orders_OrderStatus'),
         ForeignKeyConstraint(['PriceListID'], ['PriceLists.PriceListID'], name='FK__Orders__PriceLis__08B54D69'),
         ForeignKeyConstraint(['SaleConditionID'], ['SaleConditions.SaleConditionID'], name='FK__Orders__SaleCond__03F0984C'),
         ForeignKeyConstraint(['ServiceTypeID'], ['ServiceType.ServiceTypeID'], name='FK_Orders_ServiceType'),        

--- a/app/models/sysorderstatus.py
+++ b/app/models/sysorderstatus.py
@@ -17,11 +17,11 @@ from app.db import Base
 class SysOrderStatus(Base):  # <--- corregido nombre de clase
     __tablename__ = 'sysOrderStatus'
     __table_args__ = (
-        PrimaryKeyConstraint('OrderstatusID', name='PK__OrderSta__BC674F4170B3E561'),
+        PrimaryKeyConstraint('OrderStatusID', name='PK__OrderSta__BC674F4170B3E561'),
     )
 
-    OrderStatusID = Column("OrderstatusID", Integer, Identity(start=1, increment=1), primary_key=True)
+    OrderStatusID = Column('OrderStatusID', Integer, Identity(start=1, increment=1), primary_key=True)
     Status = Column(Unicode(50, 'Modern_Spanish_CI_AS'))
 
     # Relaciones
-    orders: Mapped[List['Orders']] = relationship('Orders', foreign_keys='[Orders.OrderStatusID]', back_populates='orderStatus_')
+    orders: Mapped[List['Orders']] = relationship('Orders', foreign_keys='Orders.OrderStatusID', back_populates='orderStatus_')


### PR DESCRIPTION
## Summary
- update `sysorderstatus` column names to match SQL schema
- fix `Orders` FK reference to `SysOrderStatus`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68813f182a9c8323b414b651e894ba5d