### PR TITLE
Fix overlapping SQLAlchemy relationships

### DIFF
--- a/app/models/companydata.py
+++ b/app/models/companydata.py
@@ -46,7 +46,7 @@ class CompanyData(Base):
         back_populates='companyData_',
         primaryjoin='CompanyData.CompanyID == foreign(Documents.CompanyID)',
         foreign_keys='Documents.CompanyID',
-        overlaps='documents',
+        overlaps='documents'
     )
     userAccess: Mapped[List['UserAccess']] = relationship(
         'UserAccess', back_populates='companyData_', overlaps='userAccess'
@@ -56,7 +56,7 @@ class CompanyData(Base):
         back_populates='companyData_',
         primaryjoin='CompanyData.CompanyID == foreign(Items.CompanyID)',
         foreign_keys='Items.CompanyID',
-        overlaps='branches',
+        overlaps='branches,items'
     )
 
     itemstock: Mapped[List['Itemstock']] = relationship(
@@ -64,10 +64,20 @@ class CompanyData(Base):
         back_populates='companyData_',
         primaryjoin='CompanyData.CompanyID == foreign(Itemstock.CompanyID)',
         foreign_keys='Itemstock.CompanyID',
-        overlaps='branches',
+        overlaps='branches,itemstock'
     )
-    orders: Mapped[List['Orders']] = relationship('Orders', back_populates='companyData_')
-    stockHistory: Mapped[List['StockHistory']] = relationship('StockHistory', back_populates='companyData_')
-    tempStockHistoryDetails: Mapped[List['TempStockHistoryDetails']] = relationship('TempStockHistoryDetails', back_populates='companyData_')
-    orderHistory: Mapped[List['OrderHistory']] = relationship('OrderHistory', back_populates='companyData_')
-    tempOrderDetails: Mapped[List['TempOrderDetails']] = relationship('TempOrderDetails', back_populates='companyData_')
+    orders: Mapped[List['Orders']] = relationship(
+        'Orders', back_populates='companyData_', overlaps='orders'
+    )
+    stockHistory: Mapped[List['StockHistory']] = relationship(
+        'StockHistory', back_populates='companyData_', overlaps='stockHistory'
+    )
+    tempStockHistoryDetails: Mapped[List['TempStockHistoryDetails']] = relationship(
+        'TempStockHistoryDetails', back_populates='companyData_', overlaps='tempStockHistoryDetails'
+    )
+    orderHistory: Mapped[List['OrderHistory']] = relationship(
+        'OrderHistory', back_populates='companyData_', overlaps='orderHistory'
+    )
+    tempOrderDetails: Mapped[List['TempOrderDetails']] = relationship(
+        'TempOrderDetails', back_populates='companyData_', overlaps='tempOrderDetails'
+    )

--- a/app/models/countries.py
+++ b/app/models/countries.py
@@ -32,6 +32,7 @@ class Countries(Base):
         back_populates='countries_',
         primaryjoin='Clients.CountryID == Countries.CountryID',
         foreign_keys='Clients.CountryID',
+        overlaps='provinces_'
     )
     suppliers: Mapped[List['Suppliers']] = relationship(
         'Suppliers',

--- a/app/models/documents.py
+++ b/app/models/documents.py
@@ -48,12 +48,16 @@ class Documents(Base):
     MaxItems = Column(Integer)
 
     # Relaciones
-    branches_: Mapped['Branches'] = relationship('Branches', back_populates='documents')
+    branches_: Mapped['Branches'] = relationship(
+        'Branches',
+        back_populates='documents',
+        overlaps='documents'
+    )
     companyData_: Mapped['CompanyData'] = relationship(
         'CompanyData',
         back_populates='documents',
         primaryjoin='foreign(Documents.CompanyID) == CompanyData.CompanyID',
         foreign_keys='Documents.CompanyID',
-        overlaps='branches_',
+        overlaps='branches_,documents'
     )
     sysDocumentTypes_: Mapped['SysDocumentTypes'] = relationship('SysDocumentTypes', back_populates='documents')

--- a/app/models/items.py
+++ b/app/models/items.py
@@ -60,14 +60,18 @@ class Items(Base):
     OEM = Column(Unicode(50, 'Modern_Spanish_CI_AS'))
 
     # Relaciones
-    branches_: Mapped[Branches] = relationship('Branches', back_populates='items')
+    branches_: Mapped[Branches] = relationship(
+        'Branches',
+        back_populates='items',
+        overlaps='items'
+    )
     brands_: Mapped[Brands] = relationship('Brands', back_populates='items')
     companyData_: Mapped[CompanyData] = relationship(
         'CompanyData',
         back_populates='items',
         primaryjoin='foreign(Items.CompanyID) == CompanyData.CompanyID',
         foreign_keys='Items.CompanyID',
-        overlaps='branches',
+        overlaps='branches_,items'
     )
     itemCategories_: Mapped[ItemCategories] = relationship('ItemCategories', back_populates='items')
     itemSubcategories_: Mapped[ItemSubcategories] = relationship('ItemSubcategories', back_populates='items')

--- a/app/models/itemstock.py
+++ b/app/models/itemstock.py
@@ -48,13 +48,17 @@ class Itemstock(Base):
     ExpiryDate = Column(Date)
 
     # Relaciones
-    branches_: Mapped[Branches] = relationship('Branches', back_populates='itemstock')
+    branches_: Mapped[Branches] = relationship(
+        'Branches',
+        back_populates='itemstock',
+        overlaps='itemstock'
+    )
     companyData_: Mapped[CompanyData] = relationship(
         'CompanyData',
         back_populates='itemstock',
         primaryjoin='foreign(Itemstock.CompanyID) == CompanyData.CompanyID',
         foreign_keys='Itemstock.CompanyID',
-        overlaps='branches',
+        overlaps='branches_,itemstock'
     )
     items_: Mapped[Items] = relationship('Items', back_populates='itemstock')
     suppliers_: Mapped[Suppliers] = relationship('Suppliers', back_populates='itemstock')

--- a/app/models/orderhistory.py
+++ b/app/models/orderhistory.py
@@ -55,10 +55,18 @@ class OrderHistory(Base):
     Comments = Column(Unicode(500, 'Modern_Spanish_CI_AS'))
 
     # Relaciones
-    branches_: Mapped['Branches'] = relationship('Branches', back_populates='orderHistory')
+    branches_: Mapped['Branches'] = relationship(
+        'Branches',
+        back_populates='orderHistory',
+        overlaps='orderHistory'
+    )
     cars_: Mapped[Optional['Cars']] = relationship('Cars', back_populates='orderHistory')
     suppliers_: Mapped['Suppliers'] = relationship('Suppliers', back_populates='orderHistory')
-    companyData_: Mapped['CompanyData'] = relationship('CompanyData', back_populates='orderHistory')
+    companyData_: Mapped['CompanyData'] = relationship(
+        'CompanyData',
+        back_populates='orderHistory',
+        overlaps='branches_,orderHistory'
+    )
     orders_: Mapped['Orders'] = relationship('Orders', back_populates='orderHistory')
     serviceType_: Mapped[Optional['ServiceType']] = relationship('ServiceType', back_populates='orderHistory')
     users_: Mapped['Users'] = relationship('Users', back_populates='orderHistory')

--- a/app/models/orders.py
+++ b/app/models/orders.py
@@ -76,10 +76,18 @@ class Orders(Base):
     Notes = Column(Unicode(500, 'Modern_Spanish_CI_AS'))
 
     # Relaciones
-    branches_: Mapped['Branches'] = relationship('Branches', back_populates='orders')
+    branches_: Mapped['Branches'] = relationship(
+        'Branches',
+        back_populates='orders',
+        overlaps='orders'
+    )
     cars_: Mapped[Optional['Cars']] = relationship('Cars', back_populates='orders')
     clients_: Mapped['Clients'] = relationship('Clients', back_populates='orders')
-    companyData_: Mapped['CompanyData'] = relationship('CompanyData', back_populates='orders')
+    companyData_: Mapped['CompanyData'] = relationship(
+        'CompanyData',
+        back_populates='orders',
+        overlaps='branches_,orders'
+    )
     discounts_: Mapped['Discounts'] = relationship('Discounts', back_populates='orders')
     sysDocumentTypes_: Mapped['SysDocumentTypes'] = relationship('SysDocumentTypes', back_populates='orders')
     orderStatus_: Mapped['SysOrderStatus'] = relationship('SysOrderStatus', foreign_keys=[OrderStatusID], back_populates='orders')   # <--- corregido acá

--- a/app/models/sysorderstatus.py
+++ b/app/models/sysorderstatus.py
@@ -14,8 +14,9 @@ from sqlalchemy.orm import Mapped, relationship
 from app.db import Base
 
 
-class SysOrderStatus(Base):  # <--- corregido nombre de clase
-    __tablename__ = 'sysOrderStatus'
+class SysOrderStatus(Base):  # <--- nombre de la clase
+    # Mantener el nombre de la tabla igual al que referencia Orders
+    __tablename__ = 'SysOrderStatus'
     __table_args__ = (
         PrimaryKeyConstraint('OrderStatusID', name='PK__OrderSta__BC674F4170B3E561'),
     )


### PR DESCRIPTION
## Summary
- fix table name for `SysOrderStatus`
- clarify relationship overlaps in SQLAlchemy models

## Testing
- `pytest -q`
- `npm run lint`
- `(cd frontend && npm run lint)`

------
https://chatgpt.com/codex/tasks/task_e_68814deca1308323af5f8cfa0a32dadf