### PR TITLE
Allow car brands without company

### DIFF
--- a/app/graphql/crud/brands.py
+++ b/app/graphql/crud/brands.py
@@ -9,6 +9,11 @@ def get_brands(db: Session):
     return db.query(Brands).all()
 
 
+def get_brands_by_company(db: Session, company_id: int):
+    """Retrieve brands filtered by CompanyID"""
+    return db.query(Brands).filter(Brands.CompanyID == company_id).all()
+
+
 def get_brands_by_id(db: Session, brandid: int):
     return db.query(Brands).filter(Brands.BrandID == brandid).first()
 

--- a/app/graphql/crud/carbrands.py
+++ b/app/graphql/crud/carbrands.py
@@ -9,6 +9,11 @@ def get_carbrands(db: Session):
     return db.query(CarBrands).all()
 
 
+def get_carbrands_by_company(db: Session, company_id: int):
+    """Retrieve car brands filtered by CompanyID"""
+    return db.query(CarBrands).filter(CarBrands.CompanyID == company_id).all()
+
+
 def get_carbrands_by_id(db: Session, carbrandid: int):
     return db.query(CarBrands).filter(CarBrands.CarBrandID == carbrandid).first()
 

--- a/app/graphql/crud/cars.py
+++ b/app/graphql/crud/cars.py
@@ -37,6 +37,37 @@ def get_cars(db: Session):
     return cars
 
 
+def get_cars_by_company(db: Session, company_id: int):
+    """Retrieve cars filtered by CompanyID"""
+    results = (
+        db.query(
+            Cars,
+            CarModels.Model.label("CarModelName"),
+            CarBrands.Name.label("CarBrandName"),
+            CarBrands.CarBrandID.label("CarBrandID"),
+            Clients.FirstName.label("ClientFirstName"),
+            Clients.LastName.label("ClientLastName"),
+        )
+        .join(CarModels, Cars.CarModelID == CarModels.CarModelID)
+        .join(CarBrands, CarModels.CarBrandID == CarBrands.CarBrandID)
+        .join(Clients, Cars.ClientID == Clients.ClientID)
+        .filter(Cars.CompanyID == company_id)
+        .all()
+    )
+
+    cars = []
+    for c, model_name, brand_name, brand_id, client_first_name, client_last_name in results:
+        setattr(c, "CarModelName", model_name)
+        setattr(c, "CarBrandName", brand_name)
+        setattr(c, "CarBrandID", brand_id)
+        setattr(c, "ClientFirstName", client_first_name)
+        setattr(c, "ClientLastName", client_last_name)
+        client_full_name = f"{client_first_name or ''} {client_last_name or ''}".strip()
+        setattr(c, "ClientName", client_full_name if client_full_name else "Sin nombre")
+        cars.append(c)
+    return cars
+
+
 def get_cars_by_id(db: Session, carid: int):
     result = db.query(
         Cars,

--- a/app/graphql/resolvers/brands.py
+++ b/app/graphql/resolvers/brands.py
@@ -2,7 +2,11 @@
 import strawberry
 from typing import List, Optional
 from app.graphql.schemas.brands import BrandsInDB
-from app.graphql.crud.brands import get_brands, get_brands_by_id
+from app.graphql.crud.brands import (
+    get_brands,
+    get_brands_by_id,
+    get_brands_by_company,
+)
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
 from strawberry.types import Info
@@ -43,6 +47,26 @@ class BrandsQuery:
                 }
                 return BrandsInDB(**data)
             return None
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def brands_by_company(self, info: Info, companyID: int) -> List[BrandsInDB]:
+        """Obtener marcas filtradas por CompanyID"""
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            items = get_brands_by_company(db, companyID)
+            result = []
+            for item in items:
+                data = {
+                    "BrandID": int(item.BrandID),
+                    "Name": str(item.Name),
+                    "IsActive": bool(item.IsActive) if item.IsActive is not None else True,
+                    "CompanyID": item.CompanyID,
+                }
+                result.append(BrandsInDB(**data))
+            return result
         finally:
             db_gen.close()
 

--- a/app/graphql/resolvers/carbrands.py
+++ b/app/graphql/resolvers/carbrands.py
@@ -2,7 +2,11 @@
 import strawberry
 from typing import List, Optional
 from app.graphql.schemas.carbrands import CarBrandsInDB
-from app.graphql.crud.carbrands import get_carbrands, get_carbrands_by_id
+from app.graphql.crud.carbrands import (
+    get_carbrands,
+    get_carbrands_by_id,
+    get_carbrands_by_company,
+)
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
 from strawberry.types import Info
@@ -26,6 +30,17 @@ class CarbrandsQuery:
         try:
             item = get_carbrands_by_id(db, id)
             return obj_to_schema(CarBrandsInDB, item) if item else None
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def carbrands_by_company(self, info: Info, companyID: int) -> List[CarBrandsInDB]:
+        """Obtener marcas filtradas por CompanyID"""
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            items = get_carbrands_by_company(db, companyID)
+            return list_to_schema(CarBrandsInDB, items)
         finally:
             db_gen.close()
 

--- a/app/graphql/resolvers/cars.py
+++ b/app/graphql/resolvers/cars.py
@@ -2,7 +2,11 @@
 import strawberry
 from typing import List, Optional
 from app.graphql.schemas.cars import CarsInDB
-from app.graphql.crud.cars import get_cars, get_cars_by_id
+from app.graphql.crud.cars import (
+    get_cars,
+    get_cars_by_id,
+    get_cars_by_company,
+)
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
 from strawberry.types import Info
@@ -26,6 +30,17 @@ class CarsQuery:
         try:
             car = get_cars_by_id(db, id)
             return obj_to_schema(CarsInDB, car) if car else None
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def cars_by_company(self, info: Info, companyID: int) -> List[CarsInDB]:
+        """Obtener autos filtrados por CompanyID"""
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            cars = get_cars_by_company(db, companyID)
+            return list_to_schema(CarsInDB, cars)
         finally:
             db_gen.close()
 

--- a/app/graphql/schemas/carbrands.py
+++ b/app/graphql/schemas/carbrands.py
@@ -5,7 +5,7 @@ from typing import Optional
 @strawberry.input
 class CarBrandsCreate:
     Name: str
-    CompanyID: int
+    CompanyID: Optional[int] = None
 
 @strawberry.input
 class CarBrandsUpdate:

--- a/app/utils/filter_schemas.py
+++ b/app/utils/filter_schemas.py
@@ -58,11 +58,13 @@ FILTER_SCHEMAS = {
     ],
     "brands": [
         {"field": "BrandID", "label": "ID de marca", "type": "number"},
+        {"field": "CompanyID", "label": "Compañía", "type": "select", "relationModel": "Company"},
         {"field": "Name", "label": "Nombre", "type": "text"},
         {"field": "IsActive", "label": "Activo", "type": "boolean"}
     ],
     "carbrands": [
         {"field": "CarBrandID", "label": "ID de marca de auto", "type": "number"},
+        {"field": "CompanyID", "label": "Compañía", "type": "select", "relationModel": "Company"},
         {"field": "Name", "label": "Nombre", "type": "text"}
     ],
     "carmodels": [
@@ -73,6 +75,7 @@ FILTER_SCHEMAS = {
     ],
     "cars": [
         {"field": "CarID", "label": "ID de auto", "type": "number"},
+        {"field": "CompanyID", "label": "Compañía", "type": "select", "relationModel": "Company"},
         {"field": "CarModelID", "label": "Modelo", "type": "select", "relationModel": "CarModel"},
         {"field": "CarModelName", "label": "Modelo (nombre)", "type": "text"},
         {"field": "CarBrandID", "label": "Marca", "type": "select", "relationModel": "CarBrand"},

--- a/frontend/src/pages/CarBrandCreate.jsx
+++ b/frontend/src/pages/CarBrandCreate.jsx
@@ -33,7 +33,7 @@ export default function CarBrandCreate({ onClose, onSave, carBrand: initialCarBr
         setError(null);
         try {
             let result;
-            const payload = { Name: name, CompanyID: parseInt(companyID) };
+            const payload = { Name: name, CompanyID: companyID ? parseInt(companyID) : null };
             if (isEdit) {
                 result = await carBrandOperations.updateCarBrand(initialCarBrand.CarBrandID, payload);
             } else {
@@ -60,9 +60,8 @@ export default function CarBrandCreate({ onClose, onSave, carBrand: initialCarBr
                         value={companyID}
                         onChange={e => setCompanyID(e.target.value)}
                         className="w-full border p-2 rounded"
-                        required
                     >
-                        <option value="">Seleccione</option>
+                        <option value="">Todos</option>
                         {companies.map(c => (
                             <option key={c.CompanyID} value={c.CompanyID}>{c.Name}</option>
                         ))}
@@ -89,7 +88,7 @@ export default function CarBrandCreate({ onClose, onSave, carBrand: initialCarBr
                     </button>
                     <button
                         type="submit"
-                        disabled={loading || !name.trim() || !companyID}
+                        disabled={loading || !name.trim()}
                         className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
                     >
                         {loading ? 'Guardando...' : 'Guardar'}

--- a/frontend/src/pages/CarCreate.jsx
+++ b/frontend/src/pages/CarCreate.jsx
@@ -71,7 +71,7 @@ export default function CarCreate({ initialData = null, onClose, onSave }) {
 
     // Filtrar marcas por compañía seleccionada
     const availableBrands = formData.carBrands.filter(b =>
-        !car.companyID || b.CompanyID === parseInt(car.companyID)
+        !car.companyID || b.CompanyID == null || b.CompanyID === parseInt(car.companyID)
     );
     // Actualizar modelos disponibles cuando cambia la marca
     const availableModels = formData.carModels.filter(

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -463,6 +463,16 @@ export const brandOperations = {
         }
     },
 
+    async getBrandsByCompany(companyID) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_BRANDS_BY_COMPANY, { companyID: parseInt(companyID) });
+            return data.brandsByCompany || [];
+        } catch (error) {
+            console.error("Error obteniendo marcas por compañía:", error);
+            throw error;
+        }
+    },
+
     async createBrand(brandData) {
         try {
             const data = await graphqlClient.mutation(MUTATIONS.CREATE_BRAND, {
@@ -516,6 +526,16 @@ export const carBrandOperations = {
             return data.carbrandsById;
         } catch (error) {
             console.error("Error obteniendo marca de auto:", error);
+            throw error;
+        }
+    },
+
+    async getCarBrandsByCompany(companyID) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_CARBRANDS_BY_COMPANY, { companyID: parseInt(companyID) });
+            return data.carbrandsByCompany || [];
+        } catch (error) {
+            console.error("Error obteniendo marcas de auto por compañía:", error);
             throw error;
         }
     },
@@ -680,6 +700,16 @@ export const carOperations = {
             return data.carsById;
         } catch (error) {
             console.error("Error obteniendo auto:", error);
+            throw error;
+        }
+    },
+
+    async getCarsByCompany(companyID) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_CARS_BY_COMPANY, { companyID: parseInt(companyID) });
+            return data.carsByCompany || [];
+        } catch (error) {
+            console.error("Error obteniendo autos por compañía:", error);
             throw error;
         }
     },

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -341,6 +341,7 @@ export const QUERIES = {
             }
             carBrands: allCarbrands {
                 CarBrandID
+                CompanyID
                 Name
             }
             carModels: allCarmodels {
@@ -546,6 +547,16 @@ export const QUERIES = {
             }
         }
     `,
+    GET_BRANDS_BY_COMPANY: `
+        query GetBrandsByCompany($companyID: Int!) {
+            brandsByCompany(companyID: $companyID) {
+                BrandID
+                CompanyID
+                Name
+                IsActive
+            }
+        }
+    `,
 
     // CATEGORÍAS DE ÍTEM
     GET_ALL_ITEMCATEGORIES: `
@@ -617,6 +628,15 @@ export const QUERIES = {
             }
         }
     `,
+    GET_CARBRANDS_BY_COMPANY: `
+        query GetCarBrandsByCompany($companyID: Int!) {
+            carbrandsByCompany(companyID: $companyID) {
+                CarBrandID
+                CompanyID
+                Name
+            }
+        }
+    `,
 
     // MODELOS DE AUTO
     GET_ALL_CARMODELS: `
@@ -655,6 +675,7 @@ export const QUERIES = {
         query GetAllCars {
             allCars {
                 CarID
+                CompanyID
                 LicensePlate
                 Year
                 CarModelID
@@ -674,6 +695,27 @@ export const QUERIES = {
     GET_CAR_BY_ID: `
         query GetCarById($id: Int!) {
             carsById(id: $id) {
+                CarID
+                CompanyID
+                LicensePlate
+                Year
+                CarModelID
+                CarModelName
+                CarBrandID
+                CarBrandName
+                ClientID
+                ClientFirstName
+                ClientLastName
+                ClientName
+                LastServiceMileage
+                IsDebtor
+                DiscountID
+            }
+        }
+    `,
+    GET_CARS_BY_COMPANY: `
+        query GetCarsByCompany($companyID: Int!) {
+            carsByCompany(companyID: $companyID) {
                 CarID
                 CompanyID
                 LicensePlate


### PR DESCRIPTION
## Summary
- permit CarBrands to have null CompanyID
- default to "Todos" on CarBrand create
- filter available car brands correctly when company selected
- request CompanyID field in car form data query
- add company filter for car brands
- add company filtering for brands and cars

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68827ab1065c8323947fe953492183f8