### PR TITLE
Allow car brands without company

### DIFF
--- a/app/graphql/crud/brands.py
+++ b/app/graphql/crud/brands.py
@@ -9,6 +9,11 @@ def get_brands(db: Session):
     return db.query(Brands).all()
 
 
+def get_brands_by_company(db: Session, company_id: int):
+    """Retrieve brands filtered by CompanyID"""
+    return db.query(Brands).filter(Brands.CompanyID == company_id).all()
+
+
 def get_brands_by_id(db: Session, brandid: int):
     return db.query(Brands).filter(Brands.BrandID == brandid).first()
 

--- a/app/graphql/crud/carbrands.py
+++ b/app/graphql/crud/carbrands.py
@@ -9,6 +9,11 @@ def get_carbrands(db: Session):
     return db.query(CarBrands).all()
 
 
+def get_carbrands_by_company(db: Session, company_id: int):
+    """Retrieve car brands filtered by CompanyID"""
+    return db.query(CarBrands).filter(CarBrands.CompanyID == company_id).all()
+
+
 def get_carbrands_by_id(db: Session, carbrandid: int):
     return db.query(CarBrands).filter(CarBrands.CarBrandID == carbrandid).first()
 

--- a/app/graphql/crud/cars.py
+++ b/app/graphql/crud/cars.py
@@ -37,6 +37,37 @@ def get_cars(db: Session):
     return cars
 
 
+def get_cars_by_company(db: Session, company_id: int):
+    """Retrieve cars filtered by CompanyID"""
+    results = (
+        db.query(
+            Cars,
+            CarModels.Model.label("CarModelName"),
+            CarBrands.Name.label("CarBrandName"),
+            CarBrands.CarBrandID.label("CarBrandID"),
+            Clients.FirstName.label("ClientFirstName"),
+            Clients.LastName.label("ClientLastName"),
+        )
+        .join(CarModels, Cars.CarModelID == CarModels.CarModelID)
+        .join(CarBrands, CarModels.CarBrandID == CarBrands.CarBrandID)
+        .join(Clients, Cars.ClientID == Clients.ClientID)
+        .filter(Cars.CompanyID == company_id)
+        .all()
+    )
+
+    cars = []
+    for c, model_name, brand_name, brand_id, client_first_name, client_last_name in results:
+        setattr(c, "CarModelName", model_name)
+        setattr(c, "CarBrandName", brand_name)
+        setattr(c, "CarBrandID", brand_id)
+        setattr(c, "ClientFirstName", client_first_name)
+        setattr(c, "ClientLastName", client_last_name)
+        client_full_name = f"{client_first_name or ''} {client_last_name or ''}".strip()
+        setattr(c, "ClientName", client_full_name if client_full_name else "Sin nombre")
+        cars.append(c)
+    return cars
+
+
 def get_cars_by_id(db: Session, carid: int):
     result = db.query(
         Cars,

--- a/app/graphql/crud/clients.py
+++ b/app/graphql/crud/clients.py
@@ -10,6 +10,19 @@ def get_clients(db: Session):
     return db.query(Clients).all()
 
 
+def get_clients_by_company(db: Session, company_id: int):
+    """Retrieve clients filtered by CompanyID"""
+    return db.query(Clients).filter(Clients.CompanyID == company_id).all()
+
+
+def get_clients_by_branch(db: Session, company_id: int, branch_id: int):
+    """Retrieve clients filtered by CompanyID and BranchID"""
+    return (
+        db.query(Clients)
+        .filter(Clients.CompanyID == company_id, Clients.BranchID == branch_id)
+        .all()
+    )
+
 def get_clients_by_id(db: Session, clientid: int):
     return db.query(Clients).filter(Clients.ClientID == clientid).first()
 

--- a/app/graphql/crud/suppliers.py
+++ b/app/graphql/crud/suppliers.py
@@ -9,6 +9,19 @@ def get_suppliers(db: Session):
     return db.query(Suppliers).all()
 
 
+def get_suppliers_by_company(db: Session, company_id: int):
+    """Retrieve suppliers filtered by CompanyID"""
+    return db.query(Suppliers).filter(Suppliers.CompanyID == company_id).all()
+
+
+def get_suppliers_by_branch(db: Session, company_id: int, branch_id: int):
+    """Retrieve suppliers filtered by CompanyID and BranchID"""
+    return (
+        db.query(Suppliers)
+        .filter(Suppliers.CompanyID == company_id, Suppliers.BranchID == branch_id)
+        .all()
+    )
+
 def get_suppliers_by_id(db: Session, supplierid: int):
     return db.query(Suppliers).filter(Suppliers.SupplierID == supplierid).first()
 

--- a/app/graphql/resolvers/brands.py
+++ b/app/graphql/resolvers/brands.py
@@ -2,7 +2,11 @@
 import strawberry
 from typing import List, Optional
 from app.graphql.schemas.brands import BrandsInDB
-from app.graphql.crud.brands import get_brands, get_brands_by_id
+from app.graphql.crud.brands import (
+    get_brands,
+    get_brands_by_id,
+    get_brands_by_company,
+)
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
 from strawberry.types import Info
@@ -43,6 +47,26 @@ class BrandsQuery:
                 }
                 return BrandsInDB(**data)
             return None
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def brands_by_company(self, info: Info, companyID: int) -> List[BrandsInDB]:
+        """Obtener marcas filtradas por CompanyID"""
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            items = get_brands_by_company(db, companyID)
+            result = []
+            for item in items:
+                data = {
+                    "BrandID": int(item.BrandID),
+                    "Name": str(item.Name),
+                    "IsActive": bool(item.IsActive) if item.IsActive is not None else True,
+                    "CompanyID": item.CompanyID,
+                }
+                result.append(BrandsInDB(**data))
+            return result
         finally:
             db_gen.close()
 

--- a/app/graphql/resolvers/carbrands.py
+++ b/app/graphql/resolvers/carbrands.py
@@ -2,7 +2,11 @@
 import strawberry
 from typing import List, Optional
 from app.graphql.schemas.carbrands import CarBrandsInDB
-from app.graphql.crud.carbrands import get_carbrands, get_carbrands_by_id
+from app.graphql.crud.carbrands import (
+    get_carbrands,
+    get_carbrands_by_id,
+    get_carbrands_by_company,
+)
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
 from strawberry.types import Info
@@ -26,6 +30,17 @@ class CarbrandsQuery:
         try:
             item = get_carbrands_by_id(db, id)
             return obj_to_schema(CarBrandsInDB, item) if item else None
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def carbrands_by_company(self, info: Info, companyID: int) -> List[CarBrandsInDB]:
+        """Obtener marcas filtradas por CompanyID"""
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            items = get_carbrands_by_company(db, companyID)
+            return list_to_schema(CarBrandsInDB, items)
         finally:
             db_gen.close()
 

--- a/app/graphql/resolvers/cars.py
+++ b/app/graphql/resolvers/cars.py
@@ -2,7 +2,11 @@
 import strawberry
 from typing import List, Optional
 from app.graphql.schemas.cars import CarsInDB
-from app.graphql.crud.cars import get_cars, get_cars_by_id
+from app.graphql.crud.cars import (
+    get_cars,
+    get_cars_by_id,
+    get_cars_by_company,
+)
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
 from strawberry.types import Info
@@ -26,6 +30,17 @@ class CarsQuery:
         try:
             car = get_cars_by_id(db, id)
             return obj_to_schema(CarsInDB, car) if car else None
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def cars_by_company(self, info: Info, companyID: int) -> List[CarsInDB]:
+        """Obtener autos filtrados por CompanyID"""
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            cars = get_cars_by_company(db, companyID)
+            return list_to_schema(CarsInDB, cars)
         finally:
             db_gen.close()
 

--- a/app/graphql/resolvers/clients.py
+++ b/app/graphql/resolvers/clients.py
@@ -2,7 +2,12 @@
 import strawberry
 from typing import List, Optional
 from app.graphql.schemas.clients import ClientsInDB
-from app.graphql.crud.clients import get_clients, get_clients_by_id
+from app.graphql.crud.clients import (
+    get_clients,
+    get_clients_by_id,
+    get_clients_by_company,
+    get_clients_by_branch,
+)
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
 from strawberry.types import Info
@@ -35,7 +40,9 @@ class ClientsQuery:
                     'City': str(client_dict['City']) if client_dict.get('City') else None,
                     'PostalCode': str(client_dict['PostalCode']) if client_dict.get('PostalCode') else None,
                     'PriceListID': int(client_dict['PriceListID']),
-                    'VendorID': int(client_dict['VendorID'])
+                    'VendorID': int(client_dict['VendorID']),
+                    'CompanyID': client_dict.get('CompanyID'),
+                    'BranchID': client_dict.get('BranchID'),
                 }
                 result.append(ClientsInDB(**filtered_dict))
             return result
@@ -66,10 +73,82 @@ class ClientsQuery:
                     'City': str(client_dict['City']) if client_dict.get('City') else None,
                     'PostalCode': str(client_dict['PostalCode']) if client_dict.get('PostalCode') else None,
                     'PriceListID': int(client_dict['PriceListID']),
-                    'VendorID': int(client_dict['VendorID'])
+                    'VendorID': int(client_dict['VendorID']),
+                    'CompanyID': client_dict.get('CompanyID'),
+                    'BranchID': client_dict.get('BranchID')
                 }
                 return ClientsInDB(**filtered_dict)
             return None
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def clients_by_company(self, info: Info, companyID: int) -> List[ClientsInDB]:
+        """Obtener clientes filtrados por CompanyID"""
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            clients = get_clients_by_company(db, companyID)
+            result = []
+            for client in clients:
+                client_dict = client.__dict__
+                filtered_dict = {
+                    'ClientID': int(client_dict['ClientID']),
+                    'DocTypeID': int(client_dict['DocTypeID']),
+                    'DocNumber': str(client_dict['DocNumber']) if client_dict.get('DocNumber') else None,
+                    'FirstName': str(client_dict['FirstName']),
+                    'LastName': str(client_dict['LastName']) if client_dict.get('LastName') else None,
+                    'Phone': str(client_dict['Phone']) if client_dict.get('Phone') else None,
+                    'Email': str(client_dict['Email']) if client_dict.get('Email') else None,
+                    'Address': str(client_dict['Address']) if client_dict.get('Address') else None,
+                    'IsActive': bool(client_dict['IsActive']),
+                    'CountryID': int(client_dict['CountryID']),
+                    'ProvinceID': int(client_dict['ProvinceID']),
+                    'City': str(client_dict['City']) if client_dict.get('City') else None,
+                    'PostalCode': str(client_dict['PostalCode']) if client_dict.get('PostalCode') else None,
+                    'PriceListID': int(client_dict['PriceListID']),
+                    'VendorID': int(client_dict['VendorID']),
+                    'CompanyID': client_dict.get('CompanyID'),
+                    'BranchID': client_dict.get('BranchID'),
+                }
+                result.append(ClientsInDB(**filtered_dict))
+            return result
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def clients_by_branch(
+        self, info: Info, companyID: int, branchID: int
+    ) -> List[ClientsInDB]:
+        """Obtener clientes filtrados por CompanyID y BranchID"""
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            clients = get_clients_by_branch(db, companyID, branchID)
+            result = []
+            for client in clients:
+                client_dict = client.__dict__
+                filtered_dict = {
+                    'ClientID': int(client_dict['ClientID']),
+                    'DocTypeID': int(client_dict['DocTypeID']),
+                    'DocNumber': str(client_dict['DocNumber']) if client_dict.get('DocNumber') else None,
+                    'FirstName': str(client_dict['FirstName']),
+                    'LastName': str(client_dict['LastName']) if client_dict.get('LastName') else None,
+                    'Phone': str(client_dict['Phone']) if client_dict.get('Phone') else None,
+                    'Email': str(client_dict['Email']) if client_dict.get('Email') else None,
+                    'Address': str(client_dict['Address']) if client_dict.get('Address') else None,
+                    'IsActive': bool(client_dict['IsActive']),
+                    'CountryID': int(client_dict['CountryID']),
+                    'ProvinceID': int(client_dict['ProvinceID']),
+                    'City': str(client_dict['City']) if client_dict.get('City') else None,
+                    'PostalCode': str(client_dict['PostalCode']) if client_dict.get('PostalCode') else None,
+                    'PriceListID': int(client_dict['PriceListID']),
+                    'VendorID': int(client_dict['VendorID']),
+                    'CompanyID': client_dict.get('CompanyID'),
+                    'BranchID': client_dict.get('BranchID'),
+                }
+                result.append(ClientsInDB(**filtered_dict))
+            return result
         finally:
             db_gen.close()
 

--- a/app/graphql/resolvers/suppliers.py
+++ b/app/graphql/resolvers/suppliers.py
@@ -2,7 +2,12 @@
 import strawberry
 from typing import List, Optional
 from app.graphql.schemas.suppliers import SuppliersInDB
-from app.graphql.crud.suppliers import get_suppliers, get_suppliers_by_id
+from app.graphql.crud.suppliers import (
+    get_suppliers,
+    get_suppliers_by_id,
+    get_suppliers_by_company,
+    get_suppliers_by_branch,
+)
 from app.db import get_db
 from app.utils import list_to_schema, obj_to_schema
 from strawberry.types import Info
@@ -27,6 +32,32 @@ class SuppliersQuery:
         try:
             supplier = get_suppliers_by_id(db, id)
             return obj_to_schema(SuppliersInDB, supplier) if supplier else None
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def suppliers_by_company(
+        self, info: Info, companyID: int
+    ) -> List[SuppliersInDB]:
+        """Obtener proveedores filtrados por CompanyID"""
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            suppliers = get_suppliers_by_company(db, companyID)
+            return list_to_schema(SuppliersInDB, suppliers)
+        finally:
+            db_gen.close()
+
+    @strawberry.field
+    def suppliers_by_branch(
+        self, info: Info, companyID: int, branchID: int
+    ) -> List[SuppliersInDB]:
+        """Obtener proveedores filtrados por CompanyID y BranchID"""
+        db_gen = get_db()
+        db = next(db_gen)
+        try:
+            suppliers = get_suppliers_by_branch(db, companyID, branchID)
+            return list_to_schema(SuppliersInDB, suppliers)
         finally:
             db_gen.close()
 

--- a/app/graphql/schemas/carbrands.py
+++ b/app/graphql/schemas/carbrands.py
@@ -5,7 +5,7 @@ from typing import Optional
 @strawberry.input
 class CarBrandsCreate:
     Name: str
-    CompanyID: int
+    CompanyID: Optional[int] = None
 
 @strawberry.input
 class CarBrandsUpdate:

--- a/app/graphql/schemas/clients.py
+++ b/app/graphql/schemas/clients.py
@@ -6,6 +6,8 @@ from typing import Optional
 class ClientsCreate:
     """Schema para crear un nuevo cliente"""
     DocTypeID: int
+    CompanyID: Optional[int] = None
+    BranchID: Optional[int] = None
     DocNumber: Optional[str] = None
     FirstName: str
     LastName: Optional[str] = None
@@ -24,6 +26,8 @@ class ClientsCreate:
 class ClientsUpdate:
     """Schema para actualizar un cliente existente"""
     DocTypeID: Optional[int] = None
+    CompanyID: Optional[int] = None
+    BranchID: Optional[int] = None
     DocNumber: Optional[str] = None
     FirstName: Optional[str] = None
     LastName: Optional[str] = None
@@ -56,6 +60,8 @@ class ClientsInDB:
     ProvinceID: int
     PriceListID: int
     VendorID: int
+    CompanyID: int | None
+    BranchID: int | None
 
 @strawberry.type
 class ClientsWithRelations:
@@ -75,6 +81,8 @@ class ClientsWithRelations:
     ProvinceID: int
     PriceListID: int
     VendorID: int
+    CompanyID: int | None
+    BranchID: int | None
     
     # Campos calculados
     FullName: Optional[str] = None

--- a/app/graphql/schemas/suppliers.py
+++ b/app/graphql/schemas/suppliers.py
@@ -5,6 +5,8 @@ from typing import Optional
 @strawberry.input
 class SuppliersCreate:
     DocTypeID: Optional[int] = None
+    CompanyID: Optional[int] = None
+    BranchID: Optional[int] = None
     DocNumber: Optional[str] = None
     FirstName: str
     LastName: Optional[str] = None
@@ -20,6 +22,8 @@ class SuppliersCreate:
 @strawberry.input
 class SuppliersUpdate:
     DocTypeID: Optional[int] = None
+    CompanyID: Optional[int] = None
+    BranchID: Optional[int] = None
     DocNumber: Optional[str] = None
     FirstName: Optional[str] = None
     LastName: Optional[str] = None
@@ -47,3 +51,5 @@ class SuppliersInDB:
     ProvinceID: Optional[int] = None
     City: Optional[str] = None
     PostalCode: Optional[str] = None
+    CompanyID: Optional[int] = None
+    BranchID: Optional[int] = None

--- a/app/models/clients.py
+++ b/app/models/clients.py
@@ -30,10 +30,17 @@ class Clients(Base):
             name='FK_Clients_Provinces',
         ),
         ForeignKeyConstraint(['VendorID'], ['Vendors.VendorID'], name='FK_Clients_Vendors'),
+        ForeignKeyConstraint(
+            ['CompanyID', 'BranchID'],
+            ['Branches.CompanyID', 'Branches.BranchID'],
+            name='FK_Clients_Branches',
+        ),
         PrimaryKeyConstraint('ClientID', name='PK__Clients__E67E1A048D5F930D')
     )
 
     ClientID = Column(Integer, Identity(start=1, increment=1), primary_key=True)
+    CompanyID = Column(Integer)
+    BranchID = Column(Integer)
     DocTypeID = Column(Integer)
     FirstName = Column(Unicode(100, 'Modern_Spanish_CI_AS'))
     IsActive = Column(Boolean, server_default=text('((1))'))

--- a/app/models/suppliers.py
+++ b/app/models/suppliers.py
@@ -29,10 +29,17 @@ class Suppliers(Base):
             ['Provinces.CountryID', 'Provinces.ProvinceID'],
             name='FK__Suppliers__Provi__44FF419A',
         ),
+        ForeignKeyConstraint(
+            ['CompanyID', 'BranchID'],
+            ['Branches.CompanyID', 'Branches.BranchID'],
+            name='FK_Suppliers_Branches',
+        ),
         PrimaryKeyConstraint('SupplierID', name='PK__Supplier__4BE6669487E21347')
     )
 
     SupplierID = Column(Integer, Identity(start=1, increment=1), primary_key=True)
+    CompanyID = Column(Integer)
+    BranchID = Column(Integer)
     DocTypeID = Column(Integer)
     FirstName = Column(Unicode(100, 'Modern_Spanish_CI_AS'))
     IsActive = Column(Boolean, server_default=text('((1))'))

--- a/app/utils/filter_schemas.py
+++ b/app/utils/filter_schemas.py
@@ -5,6 +5,8 @@ FILTER_SCHEMAS = {
         {"field": "ClientID", "label": "ID de cliente", "type": "number"},
         {"field": "DocTypeID", "label": "Tipo de documento", "type": "select", "relationModel": "DocType"},
         {"field": "DocNumber", "label": "Número de documento", "type": "text"},
+        {"field": "CompanyID", "label": "Compañía", "type": "select", "relationModel": "Company"},
+        {"field": "BranchID", "label": "Sucursal", "type": "select", "relationModel": "Branch", "dependsOn": "CompanyID"},
         {"field": "FirstName", "label": "Nombre", "type": "text"},
         {"field": "LastName", "label": "Apellido", "type": "text"},
         {"field": "Phone", "label": "Teléfono", "type": "text"},
@@ -22,6 +24,8 @@ FILTER_SCHEMAS = {
         {"field": "SupplierID", "label": "ID de proveedor", "type": "number"},
         {"field": "DocTypeID", "label": "Tipo de documento", "type": "select", "relationModel": "DocType"},
         {"field": "DocNumber", "label": "Número de documento", "type": "text"},
+        {"field": "CompanyID", "label": "Compañía", "type": "select", "relationModel": "Company"},
+        {"field": "BranchID", "label": "Sucursal", "type": "select", "relationModel": "Branch", "dependsOn": "CompanyID"},
         {"field": "FirstName", "label": "Nombre", "type": "text"},
         {"field": "LastName", "label": "Apellido", "type": "text"},
         {"field": "Phone", "label": "Teléfono", "type": "text"},
@@ -58,11 +62,13 @@ FILTER_SCHEMAS = {
     ],
     "brands": [
         {"field": "BrandID", "label": "ID de marca", "type": "number"},
+        {"field": "CompanyID", "label": "Compañía", "type": "select", "relationModel": "Company"},
         {"field": "Name", "label": "Nombre", "type": "text"},
         {"field": "IsActive", "label": "Activo", "type": "boolean"}
     ],
     "carbrands": [
         {"field": "CarBrandID", "label": "ID de marca de auto", "type": "number"},
+        {"field": "CompanyID", "label": "Compañía", "type": "select", "relationModel": "Company"},
         {"field": "Name", "label": "Nombre", "type": "text"}
     ],
     "carmodels": [
@@ -73,6 +79,7 @@ FILTER_SCHEMAS = {
     ],
     "cars": [
         {"field": "CarID", "label": "ID de auto", "type": "number"},
+        {"field": "CompanyID", "label": "Compañía", "type": "select", "relationModel": "Company"},
         {"field": "CarModelID", "label": "Modelo", "type": "select", "relationModel": "CarModel"},
         {"field": "CarModelName", "label": "Modelo (nombre)", "type": "text"},
         {"field": "CarBrandID", "label": "Marca", "type": "select", "relationModel": "CarBrand"},

--- a/frontend/src/pages/CarBrandCreate.jsx
+++ b/frontend/src/pages/CarBrandCreate.jsx
@@ -33,7 +33,7 @@ export default function CarBrandCreate({ onClose, onSave, carBrand: initialCarBr
         setError(null);
         try {
             let result;
-            const payload = { Name: name, CompanyID: parseInt(companyID) };
+            const payload = { Name: name, CompanyID: companyID ? parseInt(companyID) : null };
             if (isEdit) {
                 result = await carBrandOperations.updateCarBrand(initialCarBrand.CarBrandID, payload);
             } else {
@@ -60,9 +60,8 @@ export default function CarBrandCreate({ onClose, onSave, carBrand: initialCarBr
                         value={companyID}
                         onChange={e => setCompanyID(e.target.value)}
                         className="w-full border p-2 rounded"
-                        required
                     >
-                        <option value="">Seleccione</option>
+                        <option value="">Todos</option>
                         {companies.map(c => (
                             <option key={c.CompanyID} value={c.CompanyID}>{c.Name}</option>
                         ))}
@@ -89,7 +88,7 @@ export default function CarBrandCreate({ onClose, onSave, carBrand: initialCarBr
                     </button>
                     <button
                         type="submit"
-                        disabled={loading || !name.trim() || !companyID}
+                        disabled={loading || !name.trim()}
                         className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
                     >
                         {loading ? 'Guardando...' : 'Guardar'}

--- a/frontend/src/pages/CarCreate.jsx
+++ b/frontend/src/pages/CarCreate.jsx
@@ -71,7 +71,7 @@ export default function CarCreate({ initialData = null, onClose, onSave }) {
 
     // Filtrar marcas por compañía seleccionada
     const availableBrands = formData.carBrands.filter(b =>
-        !car.companyID || b.CompanyID === parseInt(car.companyID)
+        !car.companyID || b.CompanyID == null || b.CompanyID === parseInt(car.companyID)
     );
     // Actualizar modelos disponibles cuando cambia la marca
     const availableModels = formData.carModels.filter(

--- a/frontend/src/pages/ClientCreate.jsx
+++ b/frontend/src/pages/ClientCreate.jsx
@@ -9,6 +9,8 @@ export default function ClientCreate({
 }) {
     const [client, setClient] = useState({
         docTypeID: "",
+        companyID: "",
+        branchID: "",
         docNumber: "",
         firstName: "",
         lastName: "",
@@ -29,7 +31,9 @@ export default function ClientCreate({
         countries: [],
         provinces: [],
         priceLists: [],
-        vendors: []
+        vendors: [],
+        companies: [],
+        branches: [],
     });
 
     const [error, setError] = useState(null);
@@ -68,6 +72,8 @@ export default function ClientCreate({
             setIsEdit(true);
             setClient({
                 docTypeID: initialClient.DocTypeID ? parseInt(initialClient.DocTypeID) : "",
+                companyID: initialClient.CompanyID ? parseInt(initialClient.CompanyID) : "",
+                branchID: initialClient.BranchID ? parseInt(initialClient.BranchID) : "",
                 docNumber: initialClient.DocNumber || "",
                 firstName: initialClient.FirstName || "",
                 lastName: initialClient.LastName || "",
@@ -111,6 +117,10 @@ export default function ClientCreate({
                 provinceID: countryProvinces.length > 0 ? countryProvinces[0].ProvinceID : ""
             }));
         }
+
+        if (name === "companyID") {
+            setClient(prev => ({ ...prev, branchID: "" }));
+        }
     };
 
     const handleSubmit = async (e) => {
@@ -151,8 +161,11 @@ export default function ClientCreate({
     };
 
     // Filtrar provincias por país seleccionado
-    const availableProvinces = formData.provinces.filter(
-        p => p.CountryID === parseInt(client.countryID)
+const availableProvinces = formData.provinces.filter(
+    p => p.CountryID === parseInt(client.countryID)
+);
+    const availableBranches = formData.branches.filter(
+        b => b.CompanyID === parseInt(client.companyID)
     );
 
     if (loadingForm) {
@@ -218,6 +231,45 @@ export default function ClientCreate({
                                 className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                                 maxLength={50}
                             />
+                        </div>
+                    </div>
+                </div>
+                {/* Organización */}
+                <div className="bg-gray-50 p-4 rounded-lg">
+                    <h3 className="text-lg font-semibold mb-4">Organización</h3>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">Compañía</label>
+                            <select
+                                name="companyID"
+                                value={client.companyID}
+                                onChange={handleChange}
+                                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                            >
+                                <option value="">Seleccione</option>
+                                {formData.companies.map(c => (
+                                    <option key={c.CompanyID} value={c.CompanyID}>{c.Name}</option>
+                                ))}
+                            </select>
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-2">Sucursal</label>
+                            <select
+                                name="branchID"
+                                value={client.branchID}
+                                onChange={handleChange}
+                                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                disabled={!client.companyID}
+                            >
+                                <option value="">Seleccione</option>
+                                {availableBranches.length > 0 ? (
+                                    availableBranches.map(b => (
+                                        <option key={b.BranchID} value={b.BranchID}>{b.Name}</option>
+                                    ))
+                                ) : (
+                                    <option value="">No hay sucursales</option>
+                                )}
+                            </select>
                         </div>
                     </div>
                 </div>

--- a/frontend/src/pages/SupplierCreate.jsx
+++ b/frontend/src/pages/SupplierCreate.jsx
@@ -4,6 +4,8 @@ import { supplierOperations } from "../utils/graphqlClient";
 export default function SupplierCreate({ onClose, onSave, supplier: initialSupplier = null }) {
     const [supplier, setSupplier] = useState({
         docTypeID: "",
+        companyID: "",
+        branchID: "",
         docNumber: "",
         firstName: "",
         lastName: "",
@@ -21,6 +23,8 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
         sysDocTypes: [],
         countries: [],
         provinces: [],
+        companies: [],
+        branches: [],
     });
 
     const [error, setError] = useState(null);
@@ -50,6 +54,8 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
             setIsEdit(true);
             setSupplier({
                 docTypeID: initialSupplier.DocTypeID ? parseInt(initialSupplier.DocTypeID) : "",
+                companyID: initialSupplier.CompanyID ? parseInt(initialSupplier.CompanyID) : "",
+                branchID: initialSupplier.BranchID ? parseInt(initialSupplier.BranchID) : "",
                 docNumber: initialSupplier.DocNumber || "",
                 firstName: initialSupplier.FirstName || "",
                 lastName: initialSupplier.LastName || "",
@@ -85,6 +91,12 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
                 provinceID: "",
             }));
         }
+        if (name === "companyID") {
+            setSupplier(prev => ({
+                ...prev,
+                branchID: "",
+            }));
+        }
     };
 
     const handleSubmit = async (e) => {
@@ -109,6 +121,7 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
     };
 
     const availableProvinces = formData.provinces.filter(p => p.CountryID === supplier.countryID);
+    const availableBranches = formData.branches.filter(b => b.CompanyID === parseInt(supplier.companyID));
 
     if (loadingForm) {
         return (
@@ -164,6 +177,44 @@ export default function SupplierCreate({ onClose, onSave, supplier: initialSuppl
                                 className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                                 maxLength={50}
                             />
+                        </div>
+                    </div>
+                </div>
+                <div className="bg-gray-50 p-4 rounded-lg">
+                    <h3 className="text-lg font-semibold mb-4">Organización</h3>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">Compañía</label>
+                            <select
+                                name="companyID"
+                                value={supplier.companyID}
+                                onChange={handleChange}
+                                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                            >
+                                <option value="">Seleccione</option>
+                                {formData.companies.map(c => (
+                                    <option key={c.CompanyID} value={c.CompanyID}>{c.Name}</option>
+                                ))}
+                            </select>
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium mb-2">Sucursal</label>
+                            <select
+                                name="branchID"
+                                value={supplier.branchID}
+                                onChange={handleChange}
+                                className="w-full border border-gray-300 p-3 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                disabled={!supplier.companyID}
+                            >
+                                <option value="">Seleccione</option>
+                                {availableBranches.length > 0 ? (
+                                    availableBranches.map(b => (
+                                        <option key={b.BranchID} value={b.BranchID}>{b.Name}</option>
+                                    ))
+                                ) : (
+                                    <option value="">No hay sucursales</option>
+                                )}
+                            </select>
                         </div>
                     </div>
                 </div>

--- a/frontend/src/utils/graphql/operations.js
+++ b/frontend/src/utils/graphql/operations.js
@@ -28,6 +28,26 @@ export const clientOperations = {
         }
     },
 
+    async getClientsByCompany(companyID) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_CLIENTS_BY_COMPANY, { companyID: parseInt(companyID) });
+            return data.clientsByCompany || [];
+        } catch (error) {
+            console.error("Error obteniendo clientes por compañía:", error);
+            throw error;
+        }
+    },
+
+    async getClientsByBranch(companyID, branchID) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_CLIENTS_BY_BRANCH, { companyID: parseInt(companyID), branchID: parseInt(branchID) });
+            return data.clientsByBranch || [];
+        } catch (error) {
+            console.error("Error obteniendo clientes por sucursal:", error);
+            throw error;
+        }
+    },
+
     // Crear nuevo cliente
     async createClient(clientData) {
         try {
@@ -114,6 +134,8 @@ export const clientOperations = {
                 sysDocTypes: data.sysDocTypes || [],
                 countries: data.countries || [],
                 provinces: data.provinces || [],
+                companies: data.companies || [],
+                branches: data.branches || [],
                 priceLists: data.priceLists?.filter(pl => pl.IsActive) || [],
                 vendors: data.vendors?.filter(v => v.IsActive) || []
             };
@@ -132,6 +154,26 @@ export const supplierOperations = {
             return data.allSuppliers || [];
         } catch (error) {
             console.error("Error obteniendo proveedores:", error);
+            throw error;
+        }
+    },
+
+    async getSuppliersByCompany(companyID) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_SUPPLIERS_BY_COMPANY, { companyID: parseInt(companyID) });
+            return data.suppliersByCompany || [];
+        } catch (error) {
+            console.error("Error obteniendo proveedores por compañía:", error);
+            throw error;
+        }
+    },
+
+    async getSuppliersByBranch(companyID, branchID) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_SUPPLIERS_BY_BRANCH, { companyID: parseInt(companyID), branchID: parseInt(branchID) });
+            return data.suppliersByBranch || [];
+        } catch (error) {
+            console.error("Error obteniendo proveedores por sucursal:", error);
             throw error;
         }
     },
@@ -203,7 +245,9 @@ export const supplierOperations = {
             return {
                 sysDocTypes: data.sysDocTypes || [],
                 countries: data.countries || [],
-                provinces: data.provinces || []
+                provinces: data.provinces || [],
+                companies: data.companies || [],
+                branches: data.branches || []
             };
         } catch (error) {
             console.error("Error obteniendo datos del formulario:", error);
@@ -463,6 +507,16 @@ export const brandOperations = {
         }
     },
 
+    async getBrandsByCompany(companyID) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_BRANDS_BY_COMPANY, { companyID: parseInt(companyID) });
+            return data.brandsByCompany || [];
+        } catch (error) {
+            console.error("Error obteniendo marcas por compañía:", error);
+            throw error;
+        }
+    },
+
     async createBrand(brandData) {
         try {
             const data = await graphqlClient.mutation(MUTATIONS.CREATE_BRAND, {
@@ -516,6 +570,16 @@ export const carBrandOperations = {
             return data.carbrandsById;
         } catch (error) {
             console.error("Error obteniendo marca de auto:", error);
+            throw error;
+        }
+    },
+
+    async getCarBrandsByCompany(companyID) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_CARBRANDS_BY_COMPANY, { companyID: parseInt(companyID) });
+            return data.carbrandsByCompany || [];
+        } catch (error) {
+            console.error("Error obteniendo marcas de auto por compañía:", error);
             throw error;
         }
     },
@@ -680,6 +744,16 @@ export const carOperations = {
             return data.carsById;
         } catch (error) {
             console.error("Error obteniendo auto:", error);
+            throw error;
+        }
+    },
+
+    async getCarsByCompany(companyID) {
+        try {
+            const data = await graphqlClient.query(QUERIES.GET_CARS_BY_COMPANY, { companyID: parseInt(companyID) });
+            return data.carsByCompany || [];
+        } catch (error) {
+            console.error("Error obteniendo autos por compañía:", error);
             throw error;
         }
     },

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -45,6 +45,52 @@ export const QUERIES = {
             }
         }
     `,
+    GET_CLIENTS_BY_COMPANY: `
+        query GetClientsByCompany($companyID: Int!) {
+            clientsByCompany(companyID: $companyID) {
+                ClientID
+                DocTypeID
+                DocNumber
+                FirstName
+                LastName
+                Phone
+                Email
+                Address
+                City
+                PostalCode
+                IsActive
+                CountryID
+                ProvinceID
+                PriceListID
+                VendorID
+                CompanyID
+                BranchID
+            }
+        }
+    `,
+    GET_CLIENTS_BY_BRANCH: `
+        query GetClientsByBranch($companyID: Int!, $branchID: Int!) {
+            clientsByBranch(companyID: $companyID, branchID: $branchID) {
+                ClientID
+                DocTypeID
+                DocNumber
+                FirstName
+                LastName
+                Phone
+                Email
+                Address
+                City
+                PostalCode
+                IsActive
+                CountryID
+                ProvinceID
+                PriceListID
+                VendorID
+                CompanyID
+                BranchID
+            }
+        }
+    `,
 
     // DATOS MAESTROS PARA FORMULARIOS
     GET_SYSDOCUMENT_TYPES: `
@@ -310,6 +356,15 @@ export const QUERIES = {
                 VendorName
                 IsActive
             }
+            companies: allCompanydata {
+                CompanyID
+                Name
+            }
+            branches: allBranches {
+                BranchID
+                CompanyID
+                Name
+            }
         }
     `,
 
@@ -329,6 +384,15 @@ export const QUERIES = {
                 CountryID
                 Name
             }
+            companies: allCompanydata {
+                CompanyID
+                Name
+            }
+            branches: allBranches {
+                BranchID
+                CompanyID
+                Name
+            }
         }
     `,
 
@@ -341,6 +405,7 @@ export const QUERIES = {
             }
             carBrands: allCarbrands {
                 CarBrandID
+                CompanyID
                 Name
             }
             carModels: allCarmodels {
@@ -524,6 +589,48 @@ export const QUERIES = {
             }
         }
     `,
+    GET_SUPPLIERS_BY_COMPANY: `
+        query GetSuppliersByCompany($companyID: Int!) {
+            suppliersByCompany(companyID: $companyID) {
+                SupplierID
+                DocTypeID
+                DocNumber
+                FirstName
+                LastName
+                Phone
+                Email
+                Address
+                IsActive
+                CountryID
+                ProvinceID
+                City
+                PostalCode
+                CompanyID
+                BranchID
+            }
+        }
+    `,
+    GET_SUPPLIERS_BY_BRANCH: `
+        query GetSuppliersByBranch($companyID: Int!, $branchID: Int!) {
+            suppliersByBranch(companyID: $companyID, branchID: $branchID) {
+                SupplierID
+                DocTypeID
+                DocNumber
+                FirstName
+                LastName
+                Phone
+                Email
+                Address
+                IsActive
+                CountryID
+                ProvinceID
+                City
+                PostalCode
+                CompanyID
+                BranchID
+            }
+        }
+    `,
 
     // MARCAS
     GET_ALL_BRANDS: `
@@ -539,6 +646,16 @@ export const QUERIES = {
     GET_BRAND_BY_ID: `
         query GetBrandById($id: Int!) {
             brandsById(id: $id) {
+                BrandID
+                CompanyID
+                Name
+                IsActive
+            }
+        }
+    `,
+    GET_BRANDS_BY_COMPANY: `
+        query GetBrandsByCompany($companyID: Int!) {
+            brandsByCompany(companyID: $companyID) {
                 BrandID
                 CompanyID
                 Name
@@ -617,6 +734,15 @@ export const QUERIES = {
             }
         }
     `,
+    GET_CARBRANDS_BY_COMPANY: `
+        query GetCarBrandsByCompany($companyID: Int!) {
+            carbrandsByCompany(companyID: $companyID) {
+                CarBrandID
+                CompanyID
+                Name
+            }
+        }
+    `,
 
     // MODELOS DE AUTO
     GET_ALL_CARMODELS: `
@@ -655,6 +781,7 @@ export const QUERIES = {
         query GetAllCars {
             allCars {
                 CarID
+                CompanyID
                 LicensePlate
                 Year
                 CarModelID
@@ -674,6 +801,27 @@ export const QUERIES = {
     GET_CAR_BY_ID: `
         query GetCarById($id: Int!) {
             carsById(id: $id) {
+                CarID
+                CompanyID
+                LicensePlate
+                Year
+                CarModelID
+                CarModelName
+                CarBrandID
+                CarBrandName
+                ClientID
+                ClientFirstName
+                ClientLastName
+                ClientName
+                LastServiceMileage
+                IsDebtor
+                DiscountID
+            }
+        }
+    `,
+    GET_CARS_BY_COMPANY: `
+        query GetCarsByCompany($companyID: Int!) {
+            carsByCompany(companyID: $companyID) {
                 CarID
                 CompanyID
                 LicensePlate


### PR DESCRIPTION
## Summary
- permit CarBrands to have null CompanyID
- default to "Todos" on CarBrand create
- filter available car brands correctly when company selected
- request CompanyID field in car form data query
- add company filter for car brands
- add company filtering for brands and cars
- add branch and company filtering for clients and suppliers
- fix client/supplier forms to show company and branch dropdowns

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68827ab1065c8323947fe953492183f8