### PR TITLE
Add related names to Orders output

### DIFF
--- a/app/graphql/crud/orders.py
+++ b/app/graphql/crud/orders.py
@@ -38,12 +38,36 @@ def _safe_get_int(obj: Any, field_name: str) -> int:
         raise ValueError(f"No se puede convertir {field_name}={value} a int: {e}")
 
 
+from sqlalchemy.orm import joinedload
+
+
 def get_orders(db: Session):
-    return db.query(Orders).all()
+    return (
+        db.query(Orders)
+        .options(
+            joinedload(Orders.companyData_),
+            joinedload(Orders.branches_),
+            joinedload(Orders.saleConditions_),
+            joinedload(Orders.sysDocumentTypes_),
+            joinedload(Orders.warehouses_),
+        )
+        .all()
+    )
 
 
 def get_orders_by_id(db: Session, orderid: int):
-    return db.query(Orders).filter(Orders.OrderID == orderid).first()
+    return (
+        db.query(Orders)
+        .options(
+            joinedload(Orders.companyData_),
+            joinedload(Orders.branches_),
+            joinedload(Orders.saleConditions_),
+            joinedload(Orders.sysDocumentTypes_),
+            joinedload(Orders.warehouses_),
+        )
+        .filter(Orders.OrderID == orderid)
+        .first()
+    )
 
 
 def create_orders(db: Session, data: OrdersCreate):

--- a/app/graphql/schemas/orders.py
+++ b/app/graphql/schemas/orders.py
@@ -84,3 +84,8 @@ class OrdersInDB:
     NextServiceMileage: Optional[int] = None
     Notes: Optional[str] = None
     Items: Optional[List[OrderDetailsInDB]] = None
+    CompanyName: Optional[str] = None
+    BranchName: Optional[str] = None
+    SaleConditionName: Optional[str] = None
+    DocumentName: Optional[str] = None
+    WarehouseName: Optional[str] = None

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -31,6 +31,17 @@ def obj_to_schema(schema_type: Type[Any], obj: Any):
                 value = obj_dict.get(alt)
             else:
                 value = getattr(obj, alt, None)
+
+        if value is None and f.name.endswith("Name"):
+            base = f.name[:-4].lower()
+            for attr_name in dir(obj):
+                if attr_name.lower().startswith(base):
+                    rel = getattr(obj, attr_name, None)
+                    if rel is not None and hasattr(rel, "Name"):
+                        value = getattr(rel, "Name")
+                        if value is not None:
+                            break
+
         if isinstance(value, (bytes, bytearray)) and _expects_str(f.type):
             value = base64.b64encode(value).decode("utf-8")
 


### PR DESCRIPTION
## Summary
- include company, branch, sale condition, document and warehouse names in `OrdersInDB`
- eager-load relationships for order queries
- auto-populate `*Name` fields in util conversion helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688295b73a648323887e45c9ae5b569e