### PR TITLE
Clean redundant CompanyName fields

### DIFF
--- a/app/graphql/resolvers/useraccess.py
+++ b/app/graphql/resolvers/useraccess.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from app.graphql.schemas.useraccess import UserAccessInDB
 from app.graphql.crud.useraccess import get_useraccess, get_useraccess_by_id
 from app.db import get_db
+from app.utils import list_to_schema, obj_to_schema
 
 from strawberry.types import Info
 
@@ -16,20 +17,7 @@ class UseraccessQuery:
         db = next(db_gen)
         try:
             records = get_useraccess(db)
-            result = []
-            for r in records:
-                data = {
-                    'UserID': r.UserID,
-                    'CompanyID': r.CompanyID,
-                    'BranchID': r.BranchID,
-                    'RoleID': r.RoleID,
-                    'UserName': getattr(r.users_, 'FullName', None),
-                    'CompanyName': getattr(r.companyData_, 'Name', None),
-                    'BranchName': getattr(r.branches_, 'Name', None),
-                    'RoleName': getattr(r.roles_, 'RoleName', None),
-                }
-                result.append(UserAccessInDB(**data))
-            return result
+            return list_to_schema(UserAccessInDB, records)
         finally:
             db_gen.close()
 
@@ -40,19 +28,7 @@ class UseraccessQuery:
         try:
             record = get_useraccess_by_id(
                 db, userID, companyID, branchID, roleID)
-            if record:
-                data = {
-                    'UserID': record.UserID,
-                    'CompanyID': record.CompanyID,
-                    'BranchID': record.BranchID,
-                    'RoleID': record.RoleID,
-                    'UserName': getattr(record.users_, 'FullName', None),
-                    'CompanyName': getattr(record.companyData_, 'Name', None),
-                    'BranchName': getattr(record.branches_, 'Name', None),
-                    'RoleName': getattr(record.roles_, 'RoleName', None),
-                }
-                return UserAccessInDB(**data)
-            return None
+            return obj_to_schema(UserAccessInDB, record) if record else None
         finally:
             db_gen.close()
 

--- a/app/graphql/schemas/branches.py
+++ b/app/graphql/schemas/branches.py
@@ -1,6 +1,7 @@
 ﻿import base64
 import strawberry
 from typing import Optional
+from app.graphql.schemas.companydata import CompanyDataInDB
 
 
 @strawberry.input
@@ -29,4 +30,4 @@ class BranchesInDB:
     Address: Optional[str] = None
     Phone: Optional[str] = None
     Logo: Optional[str] = None  # Cambiado a str (base64)
-    CompanyName: Optional[str] = None
+    CompanyData: Optional[CompanyDataInDB] = None

--- a/app/graphql/schemas/brands.py
+++ b/app/graphql/schemas/brands.py
@@ -1,6 +1,7 @@
 # app/graphql/schemas/brands.py
 import strawberry
 from typing import Optional
+from app.graphql.schemas.companydata import CompanyDataInDB
 
 
 @strawberry.input
@@ -23,4 +24,4 @@ class BrandsInDB:
     Name: str
     IsActive: Optional[bool]
     CompanyID: Optional[int]
-    CompanyName: Optional[str] = None
+    CompanyData: Optional[CompanyDataInDB] = None

--- a/app/graphql/schemas/orders.py
+++ b/app/graphql/schemas/orders.py
@@ -1,6 +1,7 @@
 ﻿# app/graphql/schemas/orders.py
 import strawberry
 from typing import List, Optional
+from app.graphql.schemas.companydata import CompanyDataInDB
 from datetime import datetime
 from dataclasses import field
 from app.graphql.schemas.orderdetails import (
@@ -84,7 +85,7 @@ class OrdersInDB:
     NextServiceMileage: Optional[int] = None
     Notes: Optional[str] = None
     Items: Optional[List[OrderDetailsInDB]] = None
-    CompanyName: Optional[str] = None
+    CompanyData: Optional[CompanyDataInDB] = None
     BranchName: Optional[str] = None
     SaleConditionName: Optional[str] = None
     DocumentName: Optional[str] = None

--- a/app/graphql/schemas/suppliers.py
+++ b/app/graphql/schemas/suppliers.py
@@ -1,6 +1,7 @@
 # app/graphql/schemas/suppliers.py
 import strawberry
 from typing import Optional
+from app.graphql.schemas.companydata import CompanyDataInDB
 
 @strawberry.input
 class SuppliersCreate:
@@ -53,8 +54,8 @@ class SuppliersInDB:
     PostalCode: Optional[str] = None
     CompanyID: Optional[int] = None
     BranchID: Optional[int] = None
-    CompanyName: Optional[str] = None
     BranchName: Optional[str] = None
+    CompanyData: Optional[CompanyDataInDB] = None
     DocTypeName: Optional[str] = None
     CountryName: Optional[str] = None
     ProvinceName: Optional[str] = None

--- a/app/graphql/schemas/useraccess.py
+++ b/app/graphql/schemas/useraccess.py
@@ -1,6 +1,7 @@
 # app/graphql/schemas/useraccess.py
 
 import strawberry
+from app.graphql.schemas.companydata import CompanyDataInDB
 
 
 @strawberry.input
@@ -26,6 +27,6 @@ class UserAccessInDB:
     BranchID: int
     RoleID: int
     UserName: str | None = None
-    CompanyName: str | None = None
     BranchName: str | None = None
     RoleName: str | None = None
+    CompanyData: CompanyDataInDB | None = None

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -33,6 +33,12 @@ def obj_to_schema(schema_type: Any, obj: Any):
             else:
                 value = getattr(obj, alt, None)
 
+        if value is None:
+            alt_lower = f.name[0].lower() + f.name[1:]
+            value = getattr(obj, alt_lower, None)
+            if value is None:
+                value = getattr(obj, alt_lower + "_", None)
+
         suffix_map = {
             "Name": "Name",
             "DocNumber": "DocNumber",

--- a/frontend/src/pages/RolesUsers.jsx
+++ b/frontend/src/pages/RolesUsers.jsx
@@ -118,7 +118,7 @@ export default function RolesUsers() {
                     {records.map((r, idx) => (
                         <li key={idx} className="border p-2 rounded flex justify-between items-center">
                             <span>
-                                Usuario: {r.UserName || r.UserID} - Compañía: {r.CompanyName || r.CompanyID} - Sucursal: {r.BranchName || r.BranchID} - Rol: {r.RoleName || r.RoleID}
+                                Usuario: {r.UserName || r.UserID} - Compañía: {r.CompanyData?.Name || r.CompanyID} - Sucursal: {r.BranchName || r.BranchID} - Rol: {r.RoleName || r.RoleID}
                             </span>
                             <span className="space-x-2">
                                 <button onClick={() => handleEdit(r)} className="px-2 py-1 text-sm bg-gray-100 rounded hover:bg-gray-200">Editar</button>

--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -305,7 +305,6 @@ export const QUERIES = {
                 UserID
                 UserName
                 CompanyID
-                CompanyName
                 BranchID
                 BranchName
                 RoleID
@@ -320,7 +319,6 @@ export const QUERIES = {
                 UserID
                 UserName
                 CompanyID
-                CompanyName
                 BranchID
                 BranchName
                 RoleID


### PR DESCRIPTION
## Summary
- drop `CompanyName` from Branches, Brands, Orders, Suppliers and UserAccess schemas
- show company name through `CompanyData` in `RolesUsers` page
- stop requesting `CompanyName` in user access queries

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68858b7c7ebc8323aa7db0ebc4856592