### PR TITLE
Fix overlapping relationships warnings

### DIFF
--- a/app/models/clients.py
+++ b/app/models/clients.py
@@ -83,8 +83,9 @@ class Clients(Base):
         foreign_keys='[Clients.CompanyID, Clients.BranchID]'
     )
     companyData_: Mapped['CompanyData'] = relationship(
-        'CompanyData', 
+        'CompanyData',
         back_populates='clients',
         primaryjoin='Clients.CompanyID == CompanyData.CompanyID',
-        foreign_keys='[Clients.CompanyID]'
+        foreign_keys='[Clients.CompanyID]',
+        overlaps='branches_,clients'
     )

--- a/app/models/companydata.py
+++ b/app/models/companydata.py
@@ -83,9 +83,10 @@ class CompanyData(Base):
         'TempOrderDetails', back_populates='companyData_', overlaps='tempOrderDetails'
     )    
     clients: Mapped[List['Clients']] = relationship(
-        'Clients', 
+        'Clients',
         back_populates='companyData_',
         primaryjoin='CompanyData.CompanyID == foreign(Clients.CompanyID)',
-        foreign_keys='[Clients.CompanyID]'
+        foreign_keys='[Clients.CompanyID]',
+        overlaps='branches_,clients'
     )
 


### PR DESCRIPTION
## Summary
- silence SQLAlchemy warnings by adding the `overlaps` parameter to conflicting relationships

## Testing
- `python -m py_compile app/models/clients.py app/models/companydata.py`


------
https://chatgpt.com/codex/tasks/task_e_6885d3c4cb548323be89177bac99d955