### PR TITLE
Fix missing client company and branch fields

### DIFF
--- a/frontend/src/utils/graphql/queries.js
+++ b/frontend/src/utils/graphql/queries.js
@@ -20,6 +20,8 @@ export const QUERIES = {
                 ProvinceID
                 PriceListID
                 VendorID
+                CompanyID
+                BranchID
             }
         }
     `,
@@ -42,6 +44,8 @@ export const QUERIES = {
                 ProvinceID
                 PriceListID
                 VendorID
+                CompanyID
+                BranchID
             }
         }
     `,


### PR DESCRIPTION
## Summary
- include `CompanyID` and `BranchID` in `GET_ALL_CLIENTS` and `GET_CLIENT_BY_ID`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885db3f2c788323ac8761cb2e57b7a7