### PR TITLE
Use GrossIncome and StartDate in company data GraphQL API

### DIFF
--- a/app/graphql/crud/companydata.py
+++ b/app/graphql/crud/companydata.py
@@ -1,4 +1,4 @@
-﻿# crud/companydata.py
+# app/graphql/crud/companydata.py
 from sqlalchemy.orm import Session
 from app.models.companydata import CompanyData
 from app.graphql.schemas.companydata import CompanyDataCreate, CompanyDataUpdate
@@ -27,12 +27,6 @@ def create_companydata(db: Session, data: CompanyDataCreate):
     if data_dict.get("Logo"):
         data_dict["Logo"] = _decode_logo(data_dict["Logo"])
 
-    # Map GraphQL field names to SQLAlchemy attribute names
-    field_map = {"Grossincome": "GrossIncome", "Startdate": "StartDate"}
-    for src, dest in field_map.items():
-        if src in data_dict:
-            data_dict[dest] = data_dict.pop(src)
-
     obj = CompanyData(**data_dict)
     db.add(obj)
     db.commit()
@@ -47,10 +41,7 @@ def update_companydata(db: Session, companyID: int, data: CompanyDataUpdate):
             if v is not None:
                 if k == "Logo":
                     v = _decode_logo(v)
-
-                field_map = {"Grossincome": "GrossIncome", "Startdate": "StartDate"}
-                attr = field_map.get(k, k)
-                setattr(obj, attr, v)
+                setattr(obj, k, v)
         db.commit()
         db.refresh(obj)
     return obj

--- a/app/graphql/mutations/companydata.py
+++ b/app/graphql/mutations/companydata.py
@@ -9,6 +9,7 @@ from strawberry.types import Info
 
 @strawberry.type
 class CompanydataMutations:
+    """Mutaciones para CompanyData con campos GrossIncome y StartDate."""
     @strawberry.mutation
     def create_company(self, info: Info, data: CompanyDataCreate) -> CompanyDataInDB:
         db_gen = get_db()

--- a/app/graphql/schemas/companydata.py
+++ b/app/graphql/schemas/companydata.py
@@ -9,8 +9,8 @@ class CompanyDataCreate:
     Name: Optional[str] = None
     Address: Optional[str] = None
     CUIT: Optional[str] = None
-    Grossincome: Optional[str] = None
-    Startdate: Optional[datetime] = None
+    GrossIncome: Optional[str] = None
+    StartDate: Optional[datetime] = None
     Logo: Optional[str] = None  # Cambiar de bytes a str (base64)
 
 
@@ -19,8 +19,8 @@ class CompanyDataUpdate:
     Name: Optional[str] = None
     Address: Optional[str] = None
     CUIT: Optional[str] = None
-    Grossincome: Optional[str] = None
-    Startdate: Optional[datetime] = None
+    GrossIncome: Optional[str] = None
+    StartDate: Optional[datetime] = None
     Logo: Optional[str] = None  # Cambiar de bytes a str (base64)
 
 
@@ -30,6 +30,6 @@ class CompanyDataInDB:
     Name: Optional[str] = None
     Address: Optional[str] = None
     CUIT: Optional[str] = None
-    Grossincome: Optional[str] = None
-    Startdate: Optional[datetime] = None
+    GrossIncome: Optional[str] = None
+    StartDate: Optional[datetime] = None
     Logo: Optional[str] = None  # Cambiar de bytes a str (base64)


### PR DESCRIPTION
## Summary
- rename company data schema fields to GrossIncome and StartDate
- simplify CRUD mapping for new field names
- document field usage in mutations

## Testing
- `pytest` *(fails: DBAPIError: [01000] [unixODBC] [Driver Manager] ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a50abc22d08323a093e76599080986