### PR TITLE
feat: link credit card groups to company

### DIFF
--- a/app/graphql/crud/creditcardgroups.py
+++ b/app/graphql/crud/creditcardgroups.py
@@ -9,8 +9,12 @@ from app.graphql.schemas.creditcardgroups import (
 )
 
 
-def get_creditcardgroups(db: Session):
-    return db.query(CreditCardGroups).all()
+def get_creditcardgroups(db: Session, company_id: int | None = None):
+    """Retrieve all credit card groups, optionally filtered by CompanyID"""
+    query = db.query(CreditCardGroups)
+    if company_id is not None:
+        query = query.filter(CreditCardGroups.CompanyID == company_id)
+    return query.all()
 
 
 def get_creditcardgroup_by_id(db: Session, id: int):

--- a/app/graphql/mutations/creditcardgroups.py
+++ b/app/graphql/mutations/creditcardgroups.py
@@ -1,3 +1,5 @@
+# app/graphql/mutations/creditcardgroups.py
+
 import strawberry
 from typing import Optional
 from app.graphql.schemas.creditcardgroups import (

--- a/app/graphql/schemas/creditcardgroups.py
+++ b/app/graphql/schemas/creditcardgroups.py
@@ -6,16 +6,19 @@ from typing import Optional
 
 @strawberry.input
 class CreditCardGroupsCreate:
+    CompanyID: Optional[int] = None
     GroupName: Optional[str] = None
 
 
 @strawberry.input
 class CreditCardGroupsUpdate:
+    CompanyID: Optional[int] = None
     GroupName: Optional[str] = None
 
 
 @strawberry.type
 class CreditCardGroupsInDB:
     CreditCardGroupID: int
+    CompanyID: Optional[int] = None
     GroupName: Optional[str] = None
 

--- a/app/models/creditcardgroups.py
+++ b/app/models/creditcardgroups.py
@@ -6,7 +6,7 @@ from typing import List, TYPE_CHECKING
 if TYPE_CHECKING:
     from app.models.creditcards import CreditCards
 
-from sqlalchemy import Column, Integer, Unicode, Identity, PrimaryKeyConstraint
+from sqlalchemy import Column, Integer, Unicode, Identity, PrimaryKeyConstraint, ForeignKeyConstraint
 from sqlalchemy.orm import Mapped, relationship
 from app.db import Base
 
@@ -14,10 +14,12 @@ from app.db import Base
 class CreditCardGroups(Base):
     __tablename__ = 'CreditCardGroups'
     __table_args__ = (
+        ForeignKeyConstraint(['CompanyID'], ['CompanyData.CompanyID'], name='FK_CreditCardGroups_CompanyData'),
         PrimaryKeyConstraint('CreditCardGroupID', name='PK_CreditCardGroups'),
     )
 
     CreditCardGroupID = Column(Integer, Identity(start=1, increment=1), primary_key=True)
+    CompanyID = Column(Integer)
     GroupName = Column(Unicode(100, 'Modern_Spanish_CI_AS'))
 
     # Relaciones


### PR DESCRIPTION
## Summary
- add CompanyID foreign key to CreditCardGroups model
- expose CompanyID in GraphQL schemas and CRUD operations
- document mutations for credit card groups

## Testing
- `pytest tests/test_creditcardgroups.py` *(fails: Can't open lib 'ODBC Driver 17 for SQL Server')*

------
https://chatgpt.com/codex/tasks/task_e_68a50d777d1c8323a46ab319ab6f42cd