### PR TITLE
Add CompanyID relation to discounts

### DIFF
--- a/app/graphql/crud/discounts.py
+++ b/app/graphql/crud/discounts.py
@@ -1,14 +1,30 @@
-from sqlalchemy.orm import Session
+# app/graphql/crud/discounts.py
+from sqlalchemy.orm import Session, joinedload
 from app.models.discounts import Discounts
 from app.graphql.schemas.discounts import DiscountsCreate, DiscountsUpdate
 
 
 def get_discounts(db: Session):
-    return db.query(Discounts).all()
+    return db.query(Discounts).options(joinedload(Discounts.companyData_)).all()
+
+
+def get_discounts_by_company(db: Session, company_id: int):
+    """Retrieve discounts filtered by CompanyID"""
+    return (
+        db.query(Discounts)
+        .options(joinedload(Discounts.companyData_))
+        .filter(Discounts.CompanyID == company_id)
+        .all()
+    )
 
 
 def get_discounts_by_id(db: Session, discountid: int):
-    return db.query(Discounts).filter(Discounts.DiscountID == discountid).first()
+    return (
+        db.query(Discounts)
+        .options(joinedload(Discounts.companyData_))
+        .filter(Discounts.DiscountID == discountid)
+        .first()
+    )
 
 
 def create_discounts(db: Session, data: DiscountsCreate):

--- a/app/graphql/schemas/discounts.py
+++ b/app/graphql/schemas/discounts.py
@@ -1,18 +1,27 @@
 # app/graphql/schemas/discounts.py
 import strawberry
+from typing import Optional
+from app.graphql.schemas.companydata import CompanyDataInDB
+
 
 @strawberry.input
 class DiscountsCreate:
     DiscountName: str
     Percentage: float
+    CompanyID: int
+
 
 @strawberry.input
 class DiscountsUpdate:
-    DiscountName: str
-    Percentage: float
+    DiscountName: Optional[str] = None
+    Percentage: Optional[float] = None
+    CompanyID: Optional[int] = None
+
 
 @strawberry.type
 class DiscountsInDB:
     DiscountID: int
     DiscountName: str
     Percentage: float
+    CompanyID: int
+    CompanyData: Optional[CompanyDataInDB] = None

--- a/app/models/discounts.py
+++ b/app/models/discounts.py
@@ -1,15 +1,25 @@
 # ========== Discounts ===========
 # app/models/discounts.py
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .cars import Cars
     from .orders import Orders
+    from .companydata import CompanyData
 
 from typing import List
 
-from sqlalchemy import Column, Integer, Unicode, DECIMAL, Identity, PrimaryKeyConstraint, Index
+from sqlalchemy import (
+    Column,
+    Integer,
+    Unicode,
+    DECIMAL,
+    Identity,
+    PrimaryKeyConstraint,
+    Index,
+    ForeignKeyConstraint,
+)
 from sqlalchemy.orm import Mapped, relationship
 from app.db import Base
 
@@ -17,14 +27,17 @@ from app.db import Base
 class Discounts(Base):
     __tablename__ = 'Discounts'
     __table_args__ = (
-        PrimaryKeyConstraint(
-            'DiscountID', name='PK__Discount__E43F6DF6AAF602B3'),
-        Index('idx_discountID', 'DiscountID')
+        ForeignKeyConstraint(
+            ['CompanyID'], ['CompanyData.CompanyID'], name='FK_Discounts_CompanyData'
+        ),
+        PrimaryKeyConstraint('DiscountID', name='PK__Discount__E43F6DF6AAF602B3'),
+        Index('idx_discountID', 'DiscountID'),
     )
 
-    DiscountID = Column(Integer, Identity(
-        start=1, increment=1), primary_key=True)
+    DiscountID = Column(Integer, Identity(start=1, increment=1), primary_key=True)
+    CompanyID = Column(Integer)
     DiscountName = Column(Unicode(100, 'Modern_Spanish_CI_AS'))
     Percentage = Column(DECIMAL(5, 2))
 
     # Relaciones
+    companyData_: Mapped['CompanyData'] = relationship('CompanyData')

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -1,11 +1,22 @@
 import pytest
-from app.graphql.crud.discounts import create_discounts, get_discounts, update_discounts, delete_discounts
+from app.graphql.crud.discounts import (
+    create_discounts,
+    get_discounts,
+    update_discounts,
+    delete_discounts,
+)
 from app.graphql.schemas.discounts import DiscountsCreate, DiscountsUpdate
+from app.models.companydata import CompanyData
 
 
 def test_create_get_update_delete_discounts(db_session):
+    # Crear dependencia CompanyData
+    company = CompanyData(Name="Test Company")
+    db_session.add(company)
+    db_session.commit()
+    db_session.refresh(company)
     # Crear
-    data = DiscountsCreate(DiscountName="Descuento Test", Percentage=10.0)
+    data = DiscountsCreate(DiscountName="Descuento Test", Percentage=10.0, CompanyID=company.CompanyID)
     obj = create_discounts(db_session, data)
     assert obj.DiscountName == "Descuento Test"
     # Obtener


### PR DESCRIPTION
## Summary
- add CompanyID foreign key and relation in Discounts model
- expose CompanyID through GraphQL schema and CRUD, including filter by company
- adjust discounts tests for CompanyData dependency

## Testing
- `pytest` *(fails: ('01000', "[01000] [unixODBC][Driver Manager]Can't open lib 'ODBC Driver 17 for SQL Server' : file not found"))*

------
https://chatgpt.com/codex/tasks/task_e_68a5121905a08323bbfed01e5d06d991