### PR TITLE
Add required TransactionDate to stock history creation

### DIFF
--- a/app/graphql/crud/stockhistory.py
+++ b/app/graphql/crud/stockhistory.py
@@ -15,7 +15,20 @@ def get_stockhistory_by_id(db: Session, history_id: int):
 
 
 def create_stockhistory(db: Session, data: StockHistoryCreate):
-    obj = StockHistory(**vars(data))
+    obj = StockHistory(
+        CompanyID=data.CompanyID,
+        BranchID=data.BranchID,
+        UserID=data.UserID,
+        ItemID=data.ItemID,
+        WarehouseID=data.WarehouseID,
+        QuantityUpdate=data.QuantityUpdate,
+        QuantityBefore=data.QuantityBefore,
+        QuantityAfter=data.QuantityAfter,
+        TransactionDate=data.TransactionDate,
+        Reason=data.Reason,
+        TransactionType=data.TransactionType,
+        Notes=data.Notes,
+    )
     db.add(obj)
     db.commit()
     db.refresh(obj)

--- a/app/graphql/mutations/stockhistory.py
+++ b/app/graphql/mutations/stockhistory.py
@@ -22,6 +22,11 @@ class StockHistoryMutations:
     def create_stockhistory(
         self, info: Info, data: StockHistoryCreate
     ) -> StockHistoryInDB:
+        """Crea un registro de historial de stock.
+
+        TransactionDate es un campo requerido y debe ser proporcionado
+        en los datos de entrada para asegurar la persistencia.
+        """
         db_gen = get_db()
         db = next(db_gen)
         try:

--- a/app/graphql/schemas/stockhistory.py
+++ b/app/graphql/schemas/stockhistory.py
@@ -14,6 +14,7 @@ class StockHistoryCreate:
     QuantityUpdate: int
     QuantityBefore: int
     QuantityAfter: int
+    TransactionDate: datetime
     Reason: Optional[str] = None
     TransactionType: Optional[str] = None
     Notes: Optional[str] = None
@@ -29,6 +30,7 @@ class StockHistoryUpdate:
     QuantityUpdate: Optional[int] = None
     QuantityBefore: Optional[int] = None
     QuantityAfter: Optional[int] = None
+    TransactionDate: Optional[datetime] = None
     Reason: Optional[str] = None
     TransactionType: Optional[str] = None
     Notes: Optional[str] = None

--- a/tests/test_stockhistory.py
+++ b/tests/test_stockhistory.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime
 from app.graphql.crud.stockhistory import create_stockhistory, get_stockhistory, update_stockhistory, delete_stockhistory
 from app.graphql.schemas.stockhistory import StockHistoryCreate, StockHistoryUpdate
 
@@ -26,6 +27,7 @@ def test_create_get_update_delete_stockhistory(db_session):
         QuantityUpdate=10,
         QuantityBefore=0,
         QuantityAfter=10,
+        TransactionDate=datetime.now(),
         Reason="Alta",
         TransactionType="Ingreso",
         Notes="Test"


### PR DESCRIPTION
## Summary
- require `TransactionDate` in `StockHistoryCreate`
- handle `TransactionDate` in stock history CRUD and mutation
- update stock history tests for new field

## Testing
- `pytest tests/test_stockhistory.py -q` *(fails: Can't open lib 'ODBC Driver 17 for SQL Server')*


------
https://chatgpt.com/codex/tasks/task_e_68a513a504288323981c2461fedf3a69