### PR TITLE
Ensure item relations use camel case names

### DIFF
--- a/app/graphql/resolvers/items.py
+++ b/app/graphql/resolvers/items.py
@@ -9,6 +9,8 @@ from app.graphql.schemas.itemcategories import ItemCategoriesInDB
 from app.graphql.schemas.itemsubcategories import ItemSubcategoriesInDB
 from app.graphql.schemas.suppliers import SuppliersInDB
 from app.graphql.schemas.warehouses import WarehousesInDB
+from app.graphql.schemas.companydata import CompanyDataInDB
+from app.graphql.schemas.branches import BranchesInDB
 from app.models.items import Items
 from app.models.itemstock import ItemStock
 from app.db import get_db
@@ -121,6 +123,9 @@ class ItemsQuery:
                 joinedload(Items.itemCategories_),
                 joinedload(Items.itemSubcategories_),
                 joinedload(Items.suppliers_),
+                joinedload(Items.warehouses_),
+                joinedload(Items.branches_),
+                joinedload(Items.companyData_),
                 selectinload(Items.priceListItems_),
                 selectinload(Items.itemstock_)
             )
@@ -210,6 +215,16 @@ class ItemsQuery:
                         total_stock = 0
 
                 # Obtener datos relacionados de forma segura
+                company_data = None
+                if hasattr(item, 'companyData_') and item.companyData_:
+                    company_data = obj_to_schema(
+                        CompanyDataInDB, item.companyData_)
+
+                branch_data = None
+                if hasattr(item, 'branches_') and item.branches_:
+                    branch_data = obj_to_schema(
+                        BranchesInDB, item.branches_)
+
                 brand_data = None
                 if hasattr(item, 'brands_') and item.brands_:
                     brand_data = obj_to_schema(BrandsInDB, item.brands_)
@@ -238,11 +253,13 @@ class ItemsQuery:
                     'ItemID': safe_int(getattr(item, 'ItemID', 0)),
                     'Code': safe_str(getattr(item, 'Code', '')),
                     'Description': safe_str(getattr(item, 'Description', '')),
-                    'Brand': brand_data,
-                    'Category': category_data,
-                    'Subcategory': subcategory_data,
-                    'Supplier': supplier_data,
-                    'Warehouse': warehouse_data,
+                    'CompanyData': company_data,
+                    'BranchData': branch_data,
+                    'BrandData': brand_data,
+                    'CategoryData': category_data,
+                    'SubcategoryData': subcategory_data,
+                    'SupplierData': supplier_data,
+                    'WarehouseData': warehouse_data,
                     'Price': latest_price,
                     'StockQuantity': total_stock
                 }
@@ -270,6 +287,9 @@ class ItemsQuery:
             query = db.query(Items).join(ItemStock).options(
                 joinedload(Items.brands_),
                 joinedload(Items.itemCategories_),
+                joinedload(Items.warehouses_),
+                joinedload(Items.branches_),
+                joinedload(Items.companyData_),
                 selectinload(Items.itemstock)
             ).filter(
                 Items.CompanyID == company_id,
@@ -307,15 +327,32 @@ class ItemsQuery:
                     category_data = obj_to_schema(
                         ItemCategoriesInDB, item.itemCategories_)
 
+                company_data = None
+                if hasattr(item, 'companyData_') and item.companyData_:
+                    company_data = obj_to_schema(
+                        CompanyDataInDB, item.companyData_)
+
+                branch_data = None
+                if hasattr(item, 'branches_') and item.branches_:
+                    branch_data = obj_to_schema(
+                        BranchesInDB, item.branches_)
+
+                warehouse_data = None
+                if hasattr(item, 'warehouses_') and item.warehouses_:
+                    warehouse_data = obj_to_schema(
+                        WarehousesInDB, item.warehouses_)
+
                 item_dict = {
                     'ItemID': safe_int(getattr(item, 'ItemID', 0)),
                     'Code': safe_str(getattr(item, 'Code', '')),
                     'Description': safe_str(getattr(item, 'Description', '')),
-                    'Brand': brand_data,
-                    'Category': category_data,
-                    'Subcategory': None,
-                    'Supplier': None,
-                    'Warehouse': None,
+                    'CompanyData': company_data,
+                    'BranchData': branch_data,
+                    'BrandData': brand_data,
+                    'CategoryData': category_data,
+                    'SubcategoryData': None,
+                    'SupplierData': None,
+                    'WarehouseData': warehouse_data,
                     'Price': None,
                     'StockQuantity': stock_quantity
                 }

--- a/app/graphql/schemas/items.py
+++ b/app/graphql/schemas/items.py
@@ -1,3 +1,4 @@
+# app/graphql/schemas/items.py
 import strawberry
 from typing import Optional
 from app.graphql.schemas.warehouses import WarehousesInDB
@@ -85,5 +86,15 @@ class ItemsInDB:
 
 @strawberry.type
 class ItemSearchResult:
-    items: list[ItemsInDB]
-    total: int
+    ItemID: int
+    Code: str
+    Description: str
+    CompanyData: Optional[CompanyDataInDB] = None
+    BranchData: Optional[BranchesInDB] = None
+    BrandData: Optional[BrandsInDB] = None
+    CategoryData: Optional[ItemCategoriesInDB] = None
+    SubcategoryData: Optional[ItemSubcategoriesInDB] = None
+    SupplierData: Optional[SuppliersInDB] = None
+    WarehouseData: Optional[WarehousesInDB] = None
+    Price: Optional[float] = None
+    StockQuantity: Optional[int] = None


### PR DESCRIPTION
## Summary
- Map related item fields to camel case names like CompanyData and BranchData in schema
- Add resolver logic to convert underscored relationships using `obj_to_schema`
- Fetch related entities via joinedload for complete item data

## Testing
- `pytest` *(fails: pyodbc Error: Can't open lib 'ODBC Driver 17 for SQL Server')*


------
https://chatgpt.com/codex/tasks/task_e_68a51c0f219883239416b9357aacfbe4