### PR TITLE
Add non-null constraints for sys transaction and user actions

### DIFF
--- a/app/models/sys/transactiontypes.py
+++ b/app/models/sys/transactiontypes.py
@@ -11,7 +11,7 @@ class SysTransactionTypes(Base):
     )
 
     TransactTypeID = Column(Integer, Identity(start=1, increment=1), primary_key=True)
-    TypeName = Column(Unicode(100, 'Modern_Spanish_CI_AS'))
+    TypeName = Column(Unicode(100, 'Modern_Spanish_CI_AS'), nullable=False)
 
 
 __all__ = ["SysTransactionTypes"]

--- a/app/models/sys/useractions.py
+++ b/app/models/sys/useractions.py
@@ -18,7 +18,7 @@ class SysUserActions(Base):
     )
 
     UserActionID = Column(Integer, Identity(start=1, increment=1), primary_key=True)
-    ActionName = Column(Unicode(100, 'Modern_Spanish_CI_AS'))
+    ActionName = Column(Unicode(100, 'Modern_Spanish_CI_AS'), nullable=False)
 
     # Relaciones (solo lectura)
     userActivityLog: Mapped[List['UserActivityLog']] = relationship('UserActivityLog', back_populates='sysUserActions_')

--- a/consistency_report.txt
+++ b/consistency_report.txt
@@ -1,11 +1,3 @@
-2025-08-20 02:23:07 | INFO | Reporte de consistencia generado
-2025-08-20 02:23:07 | WARNING | [MODELS→DB] Tabla en modelos y NO en DB: ItemTaxes
-2025-08-20 02:23:07 | WARNING | [MODELS→DB] Tabla en modelos y NO en DB: Taxes
-2025-08-20 02:23:07 | WARNING | [MODELS→DB] Tabla en modelos y NO en DB: sysDocTypes
-2025-08-20 02:23:07 | WARNING | [MODELS→DB] Tabla en modelos y NO en DB: sysDocumentTypes
-2025-08-20 02:23:07 | WARNING | [DB→MODELS] Tabla en DB y NO en modelos: DocTypes
-2025-08-20 02:23:07 | WARNING | [DB→MODELS] Tabla en DB y NO en modelos: DocumentTypes
-2025-08-20 02:23:07 | WARNING | [DB→MODELS] Tabla en DB y NO en modelos: LastUserLogin
-2025-08-20 02:23:07 | WARNING | [DB→MODELS] Tabla en DB y NO en modelos: StockHistory
-2025-08-20 02:23:07 | WARNING | [DB→MODELS] Tabla en DB y NO en modelos: TempStockEntries
-2025-08-20 02:23:07 | INFO | Fin del reporte
+2025-08-20 02:27:46 | INFO | Reporte de consistencia generado
+2025-08-20 02:27:46 | INFO | No se encontraron advertencias de nulabilidad
+2025-08-20 02:27:46 | INFO | Fin del reporte


### PR DESCRIPTION
## Summary
- enforce non-null TypeName for SysTransactionTypes
- enforce non-null ActionName for SysUserActions
- regenerate consistency report to verify no nullability warnings

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.graphql.schemas.systransactiontypes')*

------
https://chatgpt.com/codex/tasks/task_e_68a531fa41dc83238fdda1f35e5d558c